### PR TITLE
Add completion handler function overloads

### DIFF
--- a/src/types/Callbacks.stencil
+++ b/src/types/Callbacks.stencil
@@ -1,0 +1,27 @@
+// Regenerate by running:
+//     brew install sourcery
+//     sourcery --sources src/types/Routes.swift --templates src/types/Callbacks.stencil --output src/types/Callbacks.swift
+
+// Convenience functions for working with completion handlers.
+
+{% for protocol in types.protocols %}
+public extension {{ protocol.name }} {
+    {% for method in protocol.methods %}
+    func {{ method.callName }}({% for param in method.parameters %}{{ param.asSource }}, {% endfor %}completion: @escaping (Result<{{ method.actualReturnTypeName }}, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await {{ method.callName }}({% for param in method.parameters %}{% if param.argumentLabel %}{{ param.argumentLabel }}: {% endif %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %})))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+    {% if not forloop.last %}
+
+    {% endif %}
+    {% endfor %}
+}
+{% if not forloop.last %}
+
+{% endif %}
+{% endfor %}

--- a/src/types/Callbacks.swift
+++ b/src/types/Callbacks.swift
@@ -1,0 +1,262 @@
+// Generated using Sourcery 1.9.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// Regenerate by running:
+//     brew install sourcery
+//     sourcery --sources src/types/Routes.swift --templates src/types/Callbacks.stencil --output src/types/Callbacks.swift
+
+// Convenience functions for working with completion handlers.
+
+public extension DescopeAccessKey {
+    func exchange(accessKey: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await exchange(accessKey: accessKey)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public extension DescopeAuth {
+    func me(refreshToken: String, completion: @escaping (Result<MeResponse, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await me(refreshToken: refreshToken)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public extension DescopeMagicLink {
+    func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signUp(with: method, loginId: loginId, user: user, uri: uri)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func signIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signIn(with: method, loginId: loginId, uri: uri)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signUpOrIn(with: method, loginId: loginId, uri: uri)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func updateEmail(_ email: String, loginId: String, refreshToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await updateEmail(email, loginId: loginId, refreshToken: refreshToken)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await updatePhone(phone, with: method, loginId: loginId, refreshToken: refreshToken)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func verify(token: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await verify(token: token)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func signUpCrossDevice(with method: DeliveryMethod, loginId: String, user: User, uri: String?, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signUpCrossDevice(with: method, loginId: loginId, user: user, uri: uri)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func signInCrossDevice(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signInCrossDevice(with: method, loginId: loginId, uri: uri)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func signUpOrInCrossDevice(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signUpOrInCrossDevice(with: method, loginId: loginId, uri: uri)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public extension DescopeOAuth {
+    func start(provider: OAuthProvider, redirectURL: String?, completion: @escaping (Result<String, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await start(provider: provider, redirectURL: redirectURL)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func exchange(code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await exchange(code: code)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public extension DescopeOTP {
+    func signUp(with method: DeliveryMethod, loginId: String, user: User, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signUp(with: method, loginId: loginId, user: user)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func signIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signIn(with: method, loginId: loginId)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func signUpOrIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signUpOrIn(with: method, loginId: loginId)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func verify(with method: DeliveryMethod, loginId: String, code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await verify(with: method, loginId: loginId, code: code)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func updateEmail(_ email: String, loginId: String, refreshToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await updateEmail(email, loginId: loginId, refreshToken: refreshToken)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await updatePhone(phone, with: method, loginId: loginId, refreshToken: refreshToken)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public extension DescopeSSO {
+    func start(emailOrTenantName: String, redirectURL: String?, completion: @escaping (Result<String, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await start(emailOrTenantName: emailOrTenantName, redirectURL: redirectURL)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func exchange(code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await exchange(code: code)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public extension DescopeTOTP {
+    func signUp(loginId: String, user: User, completion: @escaping (Result<TOTPResponse, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await signUp(loginId: loginId, user: user)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func update(loginId: String, refreshToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await update(loginId: loginId, refreshToken: refreshToken)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func verify(loginId: String, code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await verify(loginId: loginId, code: code)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Add [sourcery](https://github.com/krzysztofzablocki/Sourcery) template that generates overloads of every SDK function that uses completion handlers instead of async/await.
- Regenerate by running: `sourcery --sources src/types/Routes.swift --templates src/types/Callbacks.stencil --output src/types/Callbacks.swift`

## Must
- [X] Tests
- [X] Documentation (if applicable)
