### PR TITLE
Fix issues

### DIFF
--- a/src/extensions/URLRequest.swift
+++ b/src/extensions/URLRequest.swift
@@ -2,12 +2,12 @@
 import Foundation
 
 public extension URLRequest {
-    mutating func addAuthorizationHeaderValue(session: DescopeSession) {
+    mutating func addAuthorizationHeader(from session: DescopeSession) {
         let header = authorizationHeader(projectId: session.projectId, jwt: session.sessionJwt)
         addValue(header.value, forHTTPHeaderField: header.field)
     }
     
-    mutating func addAuthorizationHeaderValue(token: DescopeToken) {
+    mutating func addAuthorizationHeader(from token: DescopeToken) {
         let header = authorizationHeader(projectId: token.projectId, jwt: token.jwt)
         addValue(header.value, forHTTPHeaderField: header.field)
     }

--- a/src/http/DescopeClient.swift
+++ b/src/http/DescopeClient.swift
@@ -56,7 +56,7 @@ class DescopeClient: HTTPClient {
     
     struct TOTPResponse: JSONResponse {
         var provisioningURL: String
-        var image: String // This is a base64 encoded image
+        var image: String
         var key: String
     }
     
@@ -130,6 +130,7 @@ class DescopeClient: HTTPClient {
     // MARK: - Enchanted Link
     
     struct EnchantedLinkResponse: JSONResponse {
+        var linkId: String
         var pendingRef: String
     }
     
@@ -155,17 +156,17 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func enchantedLinkPendingSession(pendingRef: String) async throws -> JWTResponse {
-        return try await post("enchantedlink/pending-session", body: [
-            "pendingRef": pendingRef,
-        ])
-    }
-    
-    func enchantedLinkUpdateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws {
-        try await post("enchantedlink/update/email", headers: authorization(with: refreshJwt), body: [
+    func enchantedLinkUpdateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> EnchantedLinkResponse {
+        return try await post("enchantedlink/update/email", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
             "email": email,
             "uri": uri,
+        ])
+    }
+    
+    func enchantedLinkPendingSession(pendingRef: String) async throws -> JWTResponse {
+        return try await post("enchantedlink/pending-session", body: [
+            "pendingRef": pendingRef,
         ])
     }
     

--- a/src/routes/EnchantedLink.swift
+++ b/src/routes/EnchantedLink.swift
@@ -1,6 +1,8 @@
 
 import Foundation
 
+private let defaultPollDuration: TimeInterval = 2 /* mins */ * 60 /* secs */
+
 class EnchantedLink: DescopeEnchantedLink {
     let client: DescopeClient
     
@@ -8,34 +10,58 @@ class EnchantedLink: DescopeEnchantedLink {
         self.client = client
     }
     
-    func signUp(loginId: String, user: User, uri: String?) async throws -> DescopeSession {
-        let response = try await client.enchantedLinkSignUp(loginId: loginId, user: user, uri: uri)
-        return try await pollForSession(response.pendingRef)
+    func signUp(loginId: String, user: User, uri: String?) async throws -> EnchantedLinkResponse {
+        return try await client.enchantedLinkSignUp(loginId: loginId, user: user, uri: uri).convert()
     }
     
-    func signIn(loginId: String, uri: String?) async throws -> DescopeSession {
-        let response = try await client.enchantedLinkSignIn(loginId: loginId, uri: uri)
-        return try await pollForSession(response.pendingRef)
+    func signIn(loginId: String, uri: String?) async throws -> EnchantedLinkResponse {
+        return try await client.enchantedLinkSignIn(loginId: loginId, uri: uri).convert()
     }
     
-    func signUpOrIn(loginId: String, uri: String?) async throws -> DescopeSession {
-        let response = try await client.enchantedLinkSignUpOrIn(loginId: loginId, uri: uri)
-        return try await pollForSession(response.pendingRef)
+    func signUpOrIn(loginId: String, uri: String?) async throws -> EnchantedLinkResponse {
+        return try await client.enchantedLinkSignUpOrIn(loginId: loginId, uri: uri).convert()
     }
     
-    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws {
-        try await client.enchantedLinkUpdateEmail(email, loginId: loginId, uri: uri, refreshJwt: refreshJwt)
+    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> EnchantedLinkResponse {
+        return try await client.enchantedLinkUpdateEmail(email, loginId: loginId, uri: uri, refreshJwt: refreshJwt).convert()
     }
     
-    private func pollForSession(_ pendingRef: String) async throws -> DescopeSession {
-        let pollingEndsAt = Date() + 600 // 10 minute polling window
-        while Date() < pollingEndsAt {
+    func checkForSession(pendingRef: String) async throws -> DescopeSession {
+        return try await client.enchantedLinkPendingSession(pendingRef: pendingRef).convert()
+    }
+    
+    func pollForSession(pendingRef: String, timeout: TimeInterval?) async throws -> DescopeSession {
+        let pollingEndsAt = Date() + (timeout ?? defaultPollDuration)
+        // use repeat to ensure we always check at least once
+        while true {
             do {
-                return try await client.enchantedLinkPendingSession(pendingRef: pendingRef).convert()
+                // ensure that the async task hasn't been cancelled
+                try Task.checkCancellation()
+                // check for the session once, any errors not specifically handled
+                // below are intentionally let through to the calling code
+                return try await checkForSession(pendingRef: pendingRef)
             } catch DescopeError.enchantedLinkPending {
+                // sleep for a second before checking again
                 try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+                // if the timer's expired then we throw as specific
+                // client side error that can be handled appropriately
+                // by the calling code
+                guard Date() < pollingEndsAt else { throw DescopeError.enchantedLinkExpired }
+            } catch let error as DescopeError where error == .networkError {
+                // we managed to start the enchanted link authentication
+                // so any network errors we get now are probably temporary
+                try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+                // if the timer's expired then we rethrow the network
+                // error as that was probably the cause, rather than the
+                // user not verifying the enchanted link email
+                guard Date() < pollingEndsAt else { throw error }
             }
         }
-        throw DescopeError.enchantedLinkExpired
+    }
+}
+
+private extension DescopeClient.EnchantedLinkResponse {
+    func convert() -> EnchantedLinkResponse {
+        return EnchantedLinkResponse(linkId: linkId, pendingRef: pendingRef)
     }
 }

--- a/src/routes/TOTP.swift
+++ b/src/routes/TOTP.swift
@@ -1,4 +1,9 @@
 
+import Foundation
+#if os(iOS)
+import UIKit
+#endif
+
 class TOTP: DescopeTOTP {
     let client: DescopeClient
     
@@ -7,16 +12,24 @@ class TOTP: DescopeTOTP {
     }
 
     func signUp(loginId: String, user: User) async throws -> TOTPResponse {
-        let resp = try await client.totpSignUp(loginId: loginId, user: user)
-        return TOTPResponse(provisioningURL: resp.provisioningURL, key: resp.key)
+        return try await client.totpSignUp(loginId: loginId, user: user).convert()
     }
     
     func verify(loginId: String, code: String) async throws -> DescopeSession {
         return try await client.totpVerify(loginId: loginId, code: code).convert()
     }
     
-    func update(loginId: String, refreshJwt: String) async throws -> TOTPResponse{
-        let resp = try await client.totpUpdate(loginId: loginId, refreshJwt: refreshJwt)
-        return TOTPResponse(provisioningURL: resp.provisioningURL, key: resp.key)
+    func update(loginId: String, refreshJwt: String) async throws -> TOTPResponse {
+        return try await client.totpUpdate(loginId: loginId, refreshJwt: refreshJwt).convert()
+    }
+}
+
+private extension DescopeClient.TOTPResponse {
+    func convert() throws -> TOTPResponse {
+        guard let image = Data(base64Encoded: image) else { throw DescopeError.decodeError.with(message: "Invalid image value") }
+        #if os(iOS)
+        guard let image = UIImage(data: image) else { throw DescopeError.decodeError.with(message: "Invalid image data") }
+        #endif
+        return TOTPResponse(provisioningURL: provisioningURL, image: image, key: key)
     }
 }

--- a/src/sdk/Callbacks.stencil
+++ b/src/sdk/Callbacks.stencil
@@ -1,12 +1,17 @@
 // Regenerate by running:
 //     brew install sourcery
-//     sourcery --sources src/sdk/Routes.swift --templates src/sdk/Callbacks.stencil --output src/sdk/Callbacks.swift
+//     sourcery --parseDocumentation --sources src/sdk/Routes.swift --templates src/sdk/Callbacks.stencil --output src/sdk/Callbacks.swift
 
 // Convenience functions for working with completion handlers.
+
+import Foundation
 
 {% for protocol in types.protocols %}
 public extension {{ protocol.name }} {
     {% for method in protocol.methods %}
+    {% for line in method.documentation %}
+    /// {{ line }}
+    {% endfor %}
     func {{ method.callName }}({% for param in method.parameters %}{{ param.asSource }}, {% endfor %}completion: @escaping (Result<{{ method.actualReturnTypeName }}, Error>) -> Void) {
         Task {
             do {

--- a/src/sdk/Callbacks.swift
+++ b/src/sdk/Callbacks.swift
@@ -3,11 +3,19 @@
 
 // Regenerate by running:
 //     brew install sourcery
-//     sourcery --sources src/sdk/Routes.swift --templates src/sdk/Callbacks.stencil --output src/sdk/Callbacks.swift
+//     sourcery --parseDocumentation --sources src/sdk/Routes.swift --templates src/sdk/Callbacks.stencil --output src/sdk/Callbacks.swift
 
 // Convenience functions for working with completion handlers.
 
+import Foundation
+
 public extension DescopeAccessKey {
+    /// Exchanges an access key for a `DescopeToken` that can be used to perform
+    /// authenticated requests.
+    /// 
+    /// - Parameter accessKey: the access key's clear text
+    /// 
+    /// - Returns: Upon successful exchange a `DescopeToken` is returned.
     func exchange(accessKey: String, completion: @escaping (Result<DescopeToken, Error>) -> Void) {
         Task {
             do {
@@ -20,6 +28,11 @@ public extension DescopeAccessKey {
 }
 
 public extension DescopeAuth {
+    /// Returns details about the user. The user must have an active `DescopeSession`.
+    /// 
+    /// - Parameter refreshJwt: the `refreshJwt` from an active `DescopeSession`.
+    /// 
+    /// - Returns: A `MeResponse` object with the user details.
     func me(refreshJwt: String, completion: @escaping (Result<MeResponse, Error>) -> Void) {
         Task {
             do {
@@ -30,6 +43,14 @@ public extension DescopeAuth {
         }
     }
 
+    /// Refreshes a session.
+    /// 
+    /// This can be called at any time as long as the `refreshJwt` is still valid.
+    /// Typically called when the `sessionJwt` is expired or about to be.
+    /// 
+    /// - Parameter refreshJwt: the `refreshJwt` from an active `DescopeSession`.
+    /// 
+    /// - Returns: A new `DescopeSession` with a refreshed `sessionJwt`.
     func refreshSession(refreshJwt: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
         Task {
             do {
@@ -40,6 +61,9 @@ public extension DescopeAuth {
         }
     }
 
+    /// Logs out from an active `DescopeSession`.
+    /// 
+    /// - Parameter refreshJwt: the `refreshJwt` from an active `DescopeSession`.
     func logout(refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -52,7 +76,28 @@ public extension DescopeAuth {
 }
 
 public extension DescopeEnchantedLink {
-    func signUp(loginId: String, user: User, uri: String?, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+    /// Authenticates a new user using an enchanted link, sent via email.
+    /// 
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
+    /// 
+    /// - Important: Make sure an email address is provided via
+    ///     the `user` parameter or as the `loginId` itself.
+    /// 
+    /// - Important: Make sure a default Enchanted link URI is configured
+    ///     in the Descope console, or provided by this call.
+    /// 
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier.
+    ///   - user: Metadata on the user signing up.
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    /// 
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func signUp(loginId: String, user: User, uri: String?, completion: @escaping (Result<EnchantedLinkResponse, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signUp(loginId: loginId, user: user, uri: uri)))
@@ -62,7 +107,24 @@ public extension DescopeEnchantedLink {
         }
     }
 
-    func signIn(loginId: String, uri: String?, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+    /// Authenticates an existing user using an enchanted link, sent via email.
+    /// 
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
+    /// 
+    /// - Important: Make sure a default Enchanted link URI is configured
+    ///     in the Descope console, or provided by this call.
+    /// 
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier.
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    /// 
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func signIn(loginId: String, uri: String?, completion: @escaping (Result<EnchantedLinkResponse, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signIn(loginId: loginId, uri: uri)))
@@ -72,7 +134,25 @@ public extension DescopeEnchantedLink {
         }
     }
 
-    func signUpOrIn(loginId: String, uri: String?, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+    /// Authenticates an existing user if one exists, or create a new user using an
+    /// enchanted link, sent via email.
+    /// 
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
+    /// 
+    /// - Important: Make sure a default Enchanted link URI is configured
+    ///     in the Descope console, or provided by this call.
+    /// 
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier.
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    /// 
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func signUpOrIn(loginId: String, uri: String?, completion: @escaping (Result<EnchantedLinkResponse, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signUpOrIn(loginId: loginId, uri: uri)))
@@ -82,7 +162,26 @@ public extension DescopeEnchantedLink {
         }
     }
 
-    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    /// Updates an existing user by adding an email address.
+    /// 
+    /// The email will be updated after it is verified via enchanted link. In order to
+    /// do this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    /// 
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
+    /// 
+    /// - Parameters:
+    ///   - email: The email address to add.
+    ///   - loginId: The existing user's loginId
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    /// 
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<EnchantedLinkResponse, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await updateEmail(email, loginId: loginId, uri: uri, refreshJwt: refreshJwt)))
@@ -91,9 +190,78 @@ public extension DescopeEnchantedLink {
             }
         }
     }
+
+    /// Checks if an enchanted link authentication has been verified by the user.
+    /// 
+    /// This function will only return a `DescopeSession` successfully after the user
+    /// presses the enchanted link in the authentication email.
+    /// 
+    /// - Important: This function doesn't perform any polling or waiting, so calling code
+    ///     should expect to catch any thrown `DescopeError.enchantedLinkPending` errors and
+    ///     handle them appropriately. For most use cases it might be more convenient to
+    ///     use `pollForSession` instead.
+    /// 
+    /// - Parameter pendingRef: The pendingRef value from an `EnchantedLinkResponse` object.
+    /// 
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
+    func checkForSession(pendingRef: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await checkForSession(pendingRef: pendingRef)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Waits until an enchanted link authentication has been verified by the user.
+    /// 
+    /// This function will only return a `DescopeSession` successfully after the user
+    /// presses the enchanted link in the authentication email.
+    /// 
+    /// This function calls `checkForSession` periodically until the authentication
+    /// is verified. It will keep polling even if it encounters network errors, but
+    /// any other unexpected errors will be rethrown. If the timeout expires a
+    /// `DescopeError.enchantedLinkExpired` error is thrown.
+    /// 
+    /// If the current task is cancelled, this function will stop polling and
+    /// throw a `CancellationError` as expected.
+    /// 
+    /// - Parameters:
+    ///   - pendingRef: The pendingRef value from an `EnchantedLinkResponse` object.
+    ///   - timeout: An optional number of seconds to poll for until giving up. If not
+    ///     given a default value of 2 minutes is used.
+    /// 
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
+    func pollForSession(pendingRef: String, timeout: TimeInterval?, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
+        Task {
+            do {
+                completion(.success(try await pollForSession(pendingRef: pendingRef, timeout: timeout)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
 }
 
 public extension DescopeMagicLink {
+    /// Authenticates a new user using a magic link, sent via a delivery
+    /// method of choice.
+    /// 
+    /// - Important: Make sure the delivery information corresponding with
+    ///     the delivery method is given either in the `user` parameter or as
+    ///     the `loginId` itself, i.e., the email address, phone number, etc.
+    /// 
+    /// - Important: Make sure a default magic link URI is configured
+    ///     in the Descope console, or provideded by this call.
+    /// 
+    /// - Parameters:
+    ///   - method: Deliver the magic link using this delivery method.
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier.
+    ///   - user: Metadata on the user signing up.
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
     func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -104,6 +272,18 @@ public extension DescopeMagicLink {
         }
     }
 
+    /// Authenticates an existing user using a magic link, sent via a delivery
+    /// method of choice.
+    /// 
+    /// - Important: Make sure a default magic link URI is configured
+    ///     in the Descope console, or provideded by this call.
+    /// 
+    /// - Parameters:
+    ///   - method: Deliver the magic link using this delivery method.
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier.
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
     func signIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -114,6 +294,22 @@ public extension DescopeMagicLink {
         }
     }
 
+    /// Authenticates an existing user if one exists, or creates a new user
+    /// using a magic link, sent via a delivery method of choice.
+    /// 
+    /// - Important: Make sure the delivery information corresponding with
+    ///     the delivery method is given either in the `loginId` itself,
+    ///     i.e., the email address, phone number, etc.
+    /// 
+    /// - Important: Make sure a default magic link URI is configured
+    ///     in the Descope console, or provideded by this call.
+    /// 
+    /// - Parameters:
+    ///   - method: Deliver the magic link using this delivery method.
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
     func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -124,6 +320,18 @@ public extension DescopeMagicLink {
         }
     }
 
+    /// Updates an existing user by adding an email address.
+    /// 
+    /// The email will be updated after it is verified via magic link. In order to do
+    /// this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    /// 
+    /// - Parameters:
+    ///   - email: The email address to add.
+    ///   - loginId: The existing user's loginId
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
     func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -134,6 +342,22 @@ public extension DescopeMagicLink {
         }
     }
 
+    /// Updates an existing user by adding a phone number.
+    /// 
+    /// The phone number will be updated after it is verified via magic link. In order
+    /// to do this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    /// 
+    /// - Important: Make sure the delivery information corresponding with
+    ///     the phone number enabled delivery method.
+    /// 
+    /// - Parameters:
+    ///   - phone: The phone number to add.
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: The existing user's loginId
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
     func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -144,6 +368,15 @@ public extension DescopeMagicLink {
         }
     }
 
+    /// Verifies a magic link token.
+    /// 
+    /// In order to effectively do this, the link generated should refer back to
+    /// the app, then the `t` URL parameter should be extracted and sent to this
+    /// function. Upon successful authentication a `DescopeSession` is returned.
+    /// 
+    /// - Parameter token: The extracted token from the `t` URL parameter from the magic link.
+    /// 
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
     func verify(token: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
         Task {
             do {
@@ -156,6 +389,20 @@ public extension DescopeMagicLink {
 }
 
 public extension DescopeOAuth {
+    /// Starts an OAuth redirect chain to authenticate a user.
+    /// 
+    /// It's recommended to use `ASWebAuthenticationSession` to perform the authentication.
+    /// 
+    /// - Important: Make sure a default OAuth redirect URL is configured
+    ///     in the Descope console, or provideded by this call.
+    /// 
+    /// - Parameters:
+    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - redirectURL: An optional parameter to generate the OAuth link.
+    ///     If not given, the project default will be used.
+    /// 
+    /// - Returns: A URL to redirect to in order to authenticate the user against
+    ///     the chosen provider.
     func start(provider: OAuthProvider, redirectURL: String?, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
@@ -166,6 +413,13 @@ public extension DescopeOAuth {
         }
     }
 
+    /// Completes an OAuth redirect chain by exchanging the code received in
+    /// the `code` URL parameter for a `DescopeSession`.
+    /// 
+    /// - Parameter code: The code appended to the returning URL via the
+    ///     `code` URL parameter.
+    /// 
+    /// - Returns: Upon successful exchange a `DescopeSession` is returned.
     func exchange(code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
         Task {
             do {
@@ -178,6 +432,18 @@ public extension DescopeOAuth {
 }
 
 public extension DescopeOTP {
+    /// Authenticates a new user using an OTP, sent via a delivery
+    /// method of choice.
+    /// 
+    /// - Important: Make sure the delivery information corresponding with
+    ///     the delivery method is given either in the `user` parameter or as
+    ///     the `loginId` itself, i.e., the email address, phone number, etc.
+    /// 
+    /// - Parameters:
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: What identifies the user when logging in,
+    ///     typically an email, phone, or any other unique identifier.
+    ///   - user: Metadata on the user signing up.
     func signUp(with method: DeliveryMethod, loginId: String, user: User, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -188,6 +454,13 @@ public extension DescopeOTP {
         }
     }
 
+    /// Authenticates an existing user using an OTP, sent via a delivery
+    /// method of choice.
+    /// 
+    /// - Parameters:
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: What identifies the user when logging in,
+    ///     typically an email, phone, or any other unique identifier.
     func signIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -198,6 +471,17 @@ public extension DescopeOTP {
         }
     }
 
+    /// Authenticates an existing user if one exists, or creates a new user
+    /// using an OTP, sent via a delivery method of choice.
+    /// 
+    /// - Important: Make sure the delivery information corresponding with
+    ///     the delivery method is given in the `loginId` parameter, i.e., the
+    ///     email address, phone number, etc.
+    /// 
+    /// - Parameters:
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: What identifies the user when logging in,
+    ///     typically an email, phone, or any other unique identifier
     func signUpOrIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -208,6 +492,14 @@ public extension DescopeOTP {
         }
     }
 
+    /// Verifies an OTP code sent to the user.
+    /// 
+    /// - Parameters:
+    ///   - method: Which delivery method was used to send the OTP code
+    ///   - loginId: The loginId value used to initiate the authentication.
+    ///   - code: The code to validate.
+    /// 
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
     func verify(with method: DeliveryMethod, loginId: String, code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
         Task {
             do {
@@ -218,6 +510,16 @@ public extension DescopeOTP {
         }
     }
 
+    /// Updates an existing user by adding an email address.
+    /// 
+    /// The email will be updated after it is verified via OTP. In order to do this,
+    /// the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    /// 
+    /// - Parameters:
+    ///   - email: The email address to add.
+    ///   - loginId: The existing user's loginId
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
     func updateEmail(_ email: String, loginId: String, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -228,6 +530,19 @@ public extension DescopeOTP {
         }
     }
 
+    /// Updates an existing user by adding a phone number.
+    /// 
+    /// The phone number will be updated after it is verified via OTP. In order to do
+    /// this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    /// 
+    /// - Important: Make sure delivery method is appropriate for using a phone number.
+    /// 
+    /// - Parameters:
+    ///   - phone: The phone number to add.
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: The existing user's loginId
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
     func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
@@ -240,6 +555,20 @@ public extension DescopeOTP {
 }
 
 public extension DescopeSSO {
+    /// Starts an SSO redirect chain to authenticate a user.
+    /// 
+    /// It's recommended to use `ASWebAuthenticationSession` to perform the authentication.
+    /// 
+    /// - Important: Make sure a default SSO redirect URL is configured
+    ///     in the Descope console, or provideded by this call.
+    /// 
+    /// - Parameters:
+    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - redirectURL: An optional parameter to generate the SSO link.
+    ///     If not given, the project default will be used.
+    /// 
+    /// - Returns: A URL to redirect to in order to authenticate the user against
+    ///     the chosen provider.
     func start(emailOrTenantName: String, redirectURL: String?, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
@@ -250,6 +579,13 @@ public extension DescopeSSO {
         }
     }
 
+    /// Completes an SSO redirect chain by exchanging the code received in
+    /// the `code` URL parameter for a `DescopeSession`.
+    /// 
+    /// - Parameter code: The code appended to the returning URL via the
+    ///     `code` URL parameter.
+    /// 
+    /// - Returns: Upon successful exchange a `DescopeSession` is returned.
     func exchange(code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
         Task {
             do {
@@ -262,6 +598,15 @@ public extension DescopeSSO {
 }
 
 public extension DescopeTOTP {
+    /// Authenticates a new user using a TOTP. This function returns the
+    /// key (seed) that allows authenticator apps to generate TOTP codes.
+    /// 
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier.
+    ///   - user: Metadata on the user signing up.
+    /// 
+    /// - Returns: A `TOTPResponse` object with the key (seed) in multiple formats.
     func signUp(loginId: String, user: User, completion: @escaping (Result<TOTPResponse, Error>) -> Void) {
         Task {
             do {
@@ -272,6 +617,19 @@ public extension DescopeTOTP {
         }
     }
 
+    /// Updates an existing user by adding TOTP as an authentication method.
+    /// 
+    /// In order to do this, the user must have an active `DescopeSession` whose
+    /// `refreshJwt` should be passed as a parameter to this function.
+    /// 
+    /// The function returns the key (seed) that allows authenticator
+    /// apps to generate TOTP codes.
+    /// 
+    /// - Parameters:
+    ///   - loginId: The existing user's loginId
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    /// 
+    /// - Returns: A `TOTPResponse` object with the key (seed) in multiple formats.
     func update(loginId: String, refreshJwt: String, completion: @escaping (Result<TOTPResponse, Error>) -> Void) {
         Task {
             do {
@@ -282,6 +640,13 @@ public extension DescopeTOTP {
         }
     }
 
+    /// Verifies a TOTP code that was generated by an authenticator app.
+    /// 
+    /// - Parameters:
+    ///   - loginId: The `loginId` of the user trying to log in.
+    ///   - code: The code to validate.
+    /// 
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
     func verify(loginId: String, code: String, completion: @escaping (Result<DescopeSession, Error>) -> Void) {
         Task {
             do {

--- a/src/sdk/Routes.swift
+++ b/src/sdk/Routes.swift
@@ -1,11 +1,14 @@
+
+import Foundation
+
 /// General authentication functions
 public protocol DescopeAuth {
     
     /// Returns details about the user. The user must have an active `DescopeSession`.
     ///
-    /// - Returns: A `MeResponse` object with the user details.
-    ///
     /// - Parameter refreshJwt: the `refreshJwt` from an active `DescopeSession`.
+    ///
+    /// - Returns: A `MeResponse` object with the user details.
     func me(refreshJwt: String) async throws -> MeResponse
     
     /// Refreshes a session.
@@ -13,9 +16,9 @@ public protocol DescopeAuth {
     /// This can be called at any time as long as the `refreshJwt` is still valid.
     /// Typically called when the `sessionJwt` is expired or about to be.
     ///
-    /// - Returns: A new `DescopeSession` with a refreshed `sessionJwt`.
-    ///
     /// - Parameter refreshJwt: the `refreshJwt` from an active `DescopeSession`.
+    ///
+    /// - Returns: A new `DescopeSession` with a refreshed `sessionJwt`.
     func refreshSession(refreshJwt: String) async throws -> DescopeSession
     
     /// Logs out from an active `DescopeSession`.
@@ -24,16 +27,19 @@ public protocol DescopeAuth {
     func logout(refreshJwt: String) async throws
 }
 
+
 /// Access key authentication methods
 public protocol DescopeAccessKey {
+    
     /// Exchanges an access key for a `DescopeToken` that can be used to perform
     /// authenticated requests.
     ///
-    /// - Returns: Upon successful exchange a `DescopeToken` is returned.
-    ///
     /// - Parameter accessKey: the access key's clear text
+    ///
+    /// - Returns: Upon successful exchange a `DescopeToken` is returned.
     func exchange(accessKey: String) async throws -> DescopeToken
 }
+
 
 /// Authenticate users using a one time password (OTP) code, sent via
 /// a delivery method of choice. The code then needs to be verified using
@@ -45,20 +51,22 @@ public protocol DescopeOTP {
     /// method of choice.
     ///
     /// - Important: Make sure the delivery information corresponding with
-    /// the delivery method is given either in the `user` parameter or as
-    /// the `loginId` itself, i.e., the email address, phone number, etc.
+    ///     the delivery method is given either in the `user` parameter or as
+    ///     the `loginId` itself, i.e., the email address, phone number, etc.
     ///
-    /// - Parameter with: deliver the OTP code using this delivery method.
-    /// - Parameter loginId: What identifies the user when logging in,
+    /// - Parameters:
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier.
-    /// - Parameter user: Metadata on the user signing up.
+    ///   - user: Metadata on the user signing up.
     func signUp(with method: DeliveryMethod, loginId: String, user: User) async throws
     
     /// Authenticates an existing user using an OTP, sent via a delivery
     /// method of choice.
     ///
-    /// - Parameter with: deliver the OTP code using this delivery method.
-    /// - Parameter loginId: What identifies the user when logging in,
+    /// - Parameters:
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier.
     func signIn(with method: DeliveryMethod, loginId: String) async throws
     
@@ -66,44 +74,53 @@ public protocol DescopeOTP {
     /// using an OTP, sent via a delivery method of choice.
     ///
     /// - Important: Make sure the delivery information corresponding with
-    /// the delivery method is given in the `loginId` parameter, i.e., the
-    /// email address, phone number, etc.
+    ///     the delivery method is given in the `loginId` parameter, i.e., the
+    ///     email address, phone number, etc.
     ///
-    /// - Parameter with: deliver the OTP code using this delivery method.
-    /// - Parameter loginId: What identifies the user when logging in,
+    /// - Parameters:
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier
     func signUpOrIn(with method: DeliveryMethod, loginId: String) async throws
     
     /// Verifies an OTP code sent to the user.
     ///
-    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
+    /// - Parameters:
+    ///   - method: Which delivery method was used to send the OTP code
+    ///   - loginId: The loginId value used to initiate the authentication.
+    ///   - code: The code to validate.
     ///
-    /// - Parameter with: which delivery method was used to send the OTP code
-    /// - Parameter loginId: The `loginId` used to initiate the authentication.
-    /// - Parameter code: The code to validate.
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
     func verify(with method: DeliveryMethod, loginId: String, code: String) async throws -> DescopeSession
     
-    /// Updates an existing user by adding an email address. This address will
-    /// be added after it is verified via OTP. In order to do this, the user must
-    /// have an active `DescopeSession`.
+    /// Updates an existing user by adding an email address.
     ///
-    /// - Parameter email: The email address to add.
-    /// - Parameter loginId: The existing user's loginId
-    /// - Parameter refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    /// The email will be updated after it is verified via OTP. In order to do this,
+    /// the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    ///
+    /// - Parameters:
+    ///   - email: The email address to add.
+    ///   - loginId: The existing user's loginId
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
     func updateEmail(_ email: String, loginId: String, refreshJwt: String) async throws
     
-    /// Updates an existing user by adding a phone number. This number will be
-    /// added ater is is verified via OTP. In order to do this, the user must have
-    /// an active `DescopeSession`.
+    /// Updates an existing user by adding a phone number.
+    ///
+    /// The phone number will be updated after it is verified via OTP. In order to do
+    /// this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
     ///
     /// - Important: Make sure delivery method is appropriate for using a phone number.
     ///
-    /// - Parameter phone: The phone number to add.
-    /// - Parameter with: deliver the OTP code using this delivery method.
-    /// - Parameter loginId: The existing user's loginId
-    /// - Parameter refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    /// - Parameters:
+    ///   - phone: The phone number to add.
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: The existing user's loginId
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
     func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws
 }
+
 
 /// Authenticate users using Timed One-time Passwords (TOTP) codes. This
 /// authentication method is geared towards using an authenticator app which
@@ -113,32 +130,39 @@ public protocol DescopeTOTP {
     /// Authenticates a new user using a TOTP. This function returns the
     /// key (seed) that allows authenticator apps to generate TOTP codes.
     ///
-    /// - Returns: A `TOTPResponse` object with the key (seed) in multiple formats.
-    ///
-    /// - Parameter loginId: What identifies the user when logging in, typically
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
     ///     an email, phone, or any other unique identifier.
-    /// - Parameter user: Metadata on the user signing up.
+    ///   - user: Metadata on the user signing up.
+    ///
+    /// - Returns: A `TOTPResponse` object with the key (seed) in multiple formats.
     func signUp(loginId: String, user: User) async throws -> TOTPResponse
     
     /// Updates an existing user by adding TOTP as an authentication method.
-    /// In order to do this, the user must have an active `DescopeSession`.
-    /// This function returns the key (seed) that allows authenticator
+    ///
+    /// In order to do this, the user must have an active `DescopeSession` whose
+    /// `refreshJwt` should be passed as a parameter to this function.
+    ///
+    /// The function returns the key (seed) that allows authenticator
     /// apps to generate TOTP codes.
     ///
-    /// - Returns: A `TOTPResponse` object with the key (seed) in multiple formats.
+    /// - Parameters:
+    ///   - loginId: The existing user's loginId
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
     ///
-    /// - Parameter loginId: The existing user's loginId
-    /// - Parameter refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    /// - Returns: A `TOTPResponse` object with the key (seed) in multiple formats.
     func update(loginId: String, refreshJwt: String) async throws -> TOTPResponse
     
     /// Verifies a TOTP code that was generated by an authenticator app.
     ///
-    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
+    /// - Parameters:
+    ///   - loginId: The `loginId` of the user trying to log in.
+    ///   - code: The code to validate.
     ///
-    /// - Parameter loginId: The `loginId` of the user trying to log in.
-    /// - Parameter code: The code to validate.
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
     func verify(loginId: String, code: String) async throws -> DescopeSession
 }
+
 
 /// Authenticate users using a special link that once clicked, can authenticated
 /// the user. In order to correctly implement, the app must make sure the link
@@ -157,11 +181,12 @@ public protocol DescopeMagicLink {
     /// - Important: Make sure a default magic link URI is configured
     ///     in the Descope console, or provideded by this call.
     ///
-    /// - Parameter with: Deliver the magic link using this delivery method.
-    /// - Parameter loginId: What identifies the user when logging in, typically
+    /// - Parameters:
+    ///   - method: Deliver the magic link using this delivery method.
+    ///   - loginId: What identifies the user when logging in, typically
     ///     an email, phone, or any other unique identifier.
-    /// - Parameter user: Metadata on the user signing up.
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
+    ///   - user: Metadata on the user signing up.
+    ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
     func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws
     
@@ -171,10 +196,11 @@ public protocol DescopeMagicLink {
     /// - Important: Make sure a default magic link URI is configured
     ///     in the Descope console, or provideded by this call.
     ///
-    /// - Parameter with: Deliver the magic link using this delivery method.
-    /// - Parameter loginId: What identifies the user when logging in, typically
+    /// - Parameters:
+    ///   - method: Deliver the magic link using this delivery method.
+    ///   - loginId: What identifies the user when logging in, typically
     ///     an email, phone, or any other unique identifier.
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
+    ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
     func signIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws
     
@@ -188,63 +214,72 @@ public protocol DescopeMagicLink {
     /// - Important: Make sure a default magic link URI is configured
     ///     in the Descope console, or provideded by this call.
     ///
-    /// - Parameter with: Deliver the magic link using this delivery method.
-    /// - Parameter loginId: What identifies the user when logging in, typically
+    /// - Parameters:
+    ///   - method: Deliver the magic link using this delivery method.
+    ///   - loginId: What identifies the user when logging in, typically
     ///     an email, phone, or any other unique identifier
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
+    ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
     func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws
     
-    /// Updates an existing user by adding an email address. This address will be
-    /// added after it is verified via magic link. In order to do this, the user must
-    /// have an active `DescopeSession`.
+    /// Updates an existing user by adding an email address.
     ///
-    /// - Parameter email: The email address to add.
-    /// - Parameter loginId: The existing user's loginId
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
+    /// The email will be updated after it is verified via magic link. In order to do
+    /// this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    ///
+    /// - Parameters:
+    ///   - email: The email address to add.
+    ///   - loginId: The existing user's loginId
+    ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    /// - Parameter refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
     func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws
     
-    /// Updates an existing user by adding a phone number. This number will be added
-    /// after it is verified via magic link. In order to do this, the user must have
-    /// an active `DescopeSession`.
+    /// Updates an existing user by adding a phone number.
+    ///
+    /// The phone number will be updated after it is verified via magic link. In order
+    /// to do this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
     ///
     /// - Important: Make sure the delivery information corresponding with
     ///     the phone number enabled delivery method.
     ///
-    /// - Parameter phone: The phone number to add.
-    /// - Parameter with: deliver the OTP code using this delivery method.
-    /// - Parameter loginId: The existing user's loginId
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
+    /// - Parameters:
+    ///   - phone: The phone number to add.
+    ///   - method: Deliver the OTP code using this delivery method.
+    ///   - loginId: The existing user's loginId
+    ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    /// - Parameter refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
     func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws
     
     /// Verifies a magic link token.
     ///
-    /// In order to effectively do this, the link generated should refer back to the app,
-    /// then the `t` URL parameter should be extracted and sent to this function. Upon successful
-    /// authentication a `DescopeSession` is returned.
-    ///
-    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
+    /// In order to effectively do this, the link generated should refer back to
+    /// the app, then the `t` URL parameter should be extracted and sent to this
+    /// function. Upon successful authentication a `DescopeSession` is returned.
     ///
     /// - Parameter token: The extracted token from the `t` URL parameter from the magic link.
+    ///
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
     func verify(token: String) async throws -> DescopeSession
 }
 
+
 /// Authenticate users using one of three special links that once clicked, can authenticated
 /// the user. This method is geared towards cross-device authentication. In order to correctly
-/// implement, the app must make sure the link redirects to a webpage which will verify the link
+/// implement, the app must make sure the uri redirects to a webpage which will verify the link
 /// for them. The app will poll for a valid session in the meantime, and will authenticate the
 /// user as soon as they are verified via said webpage. To learn more consult the official
 /// Descope docs.
 public protocol DescopeEnchantedLink {
     
-    /// Authenticates a new user using an enchanted link, sent via email. This method
-    /// returns a `DescopeSession` once the user successfully verifies the enchanted link,
-    /// using a dedicated web page. It will throw an error if it times out during
-    /// the process.
+    /// Authenticates a new user using an enchanted link, sent via email.
+    ///
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
     ///
     /// - Important: Make sure an email address is provided via
     ///     the `user` parameter or as the `loginId` itself.
@@ -252,60 +287,114 @@ public protocol DescopeEnchantedLink {
     /// - Important: Make sure a default Enchanted link URI is configured
     ///     in the Descope console, or provided by this call.
     ///
-    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
-    ///
-    /// - Parameter loginId: What identifies the user when logging in, typically
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
     ///     an email, phone, or any other unique identifier.
-    /// - Parameter user: Metadata on the user signing up.
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
+    ///   - user: Metadata on the user signing up.
+    ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signUp(loginId: String, user: User, uri: String?) async throws -> DescopeSession
+    ///
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func signUp(loginId: String, user: User, uri: String?) async throws -> EnchantedLinkResponse
     
     /// Authenticates an existing user using an enchanted link, sent via email.
-    /// This method returns a `DescopeSession` once the user successfully verifies
-    /// the enchanted link, using a dedicated web page. It will throw an error if
-    /// it times out during the process.
+    ///
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
     ///
     /// - Important: Make sure a default Enchanted link URI is configured
     ///     in the Descope console, or provided by this call.
     ///
-    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
-    ///
-    /// - Parameter loginId: What identifies the user when logging in, typically
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
     ///     an email, phone, or any other unique identifier.
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
+    ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signIn(loginId: String, uri: String?) async throws -> DescopeSession
+    ///
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func signIn(loginId: String, uri: String?) async throws -> EnchantedLinkResponse
     
     /// Authenticates an existing user if one exists, or create a new user using an
-    /// enchanted link, sent via email. This method will return a `DescopeSession` once
-    /// the user successfully verifies the enchanted link, using a dedicated web page.
-    /// It will throw an error if it times out during the process.
+    /// enchanted link, sent via email.
+    ///
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
     ///
     /// - Important: Make sure a default Enchanted link URI is configured
-    ///     in the Descope console, or provideded by this call.
+    ///     in the Descope console, or provided by this call.
+    ///
+    /// - Parameters:
+    ///   - loginId: What identifies the user when logging in, typically
+    ///     an email, phone, or any other unique identifier.
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    ///
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func signUpOrIn(loginId: String, uri: String?) async throws -> EnchantedLinkResponse
+    
+    /// Updates an existing user by adding an email address.
+    ///
+    /// The email will be updated after it is verified via enchanted link. In order to
+    /// do this, the user must have an active `DescopeSession` whose `refreshJwt` should
+    /// be passed as a parameter to this function.
+    ///
+    /// The caller should use the returned `EnchantedLinkResponse` object to show the
+    /// user which link they need to press in the enchanted link email, and then use
+    /// the `pendingRef` value to poll until the authentication is verified.
+    ///
+    /// - Parameters:
+    ///   - email: The email address to add.
+    ///   - loginId: The existing user's loginId
+    ///   - uri: Optional URI that will be used to generate the magic link.
+    ///     If not given, the project default will be used.
+    ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
+    ///
+    /// - Returns: An `EnchantedLinkResponse` object with the `linkId` to show the
+    ///     user and `pendingRef` for polling for the session.
+    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> EnchantedLinkResponse
+    
+    /// Checks if an enchanted link authentication has been verified by the user.
+    ///
+    /// This function will only return a `DescopeSession` successfully after the user
+    /// presses the enchanted link in the authentication email.
+    ///
+    /// - Important: This function doesn't perform any polling or waiting, so calling code
+    ///     should expect to catch any thrown `DescopeError.enchantedLinkPending` errors and
+    ///     handle them appropriately. For most use cases it might be more convenient to
+    ///     use `pollForSession` instead.
+    ///
+    /// - Parameter pendingRef: The pendingRef value from an `EnchantedLinkResponse` object.
     ///
     /// - Returns: Upon successful authentication a `DescopeSession` is returned.
-    ///
-    /// - Parameter loginId: What identifies the user when logging in, typically
-    ///     an email, phone, or any other unique identifier.
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
-    ///     If not given, the project default will be used.
-    func signUpOrIn(loginId: String, uri: String?) async throws -> DescopeSession
+    func checkForSession(pendingRef: String) async throws -> DescopeSession
     
-    /// Updates an existing user by adding an email address. This address will be
-    /// added after it is verified via enchanted link. In order to do this, the user
-    /// must have an active `DescopeSession`. This method will return comeplete once
-    /// the user successfully verifies the enchanted link, using a dedicated web
-    /// page. It will throw an error if it times out during the process.
+    /// Waits until an enchanted link authentication has been verified by the user.
     ///
-    /// - Parameter email: The email address to add.
-    /// - Parameter loginId: The existing user's loginId
-    /// - Parameter uri: Optional URI that will be used to generate the magic link.
-    ///     If not given, the project default will be used.
-    /// - Parameter refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
-    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws
+    /// This function will only return a `DescopeSession` successfully after the user
+    /// presses the enchanted link in the authentication email.
+    ///
+    /// This function calls `checkForSession` periodically until the authentication
+    /// is verified. It will keep polling even if it encounters network errors, but
+    /// any other unexpected errors will be rethrown. If the timeout expires a
+    /// `DescopeError.enchantedLinkExpired` error is thrown.
+    ///
+    /// If the current task is cancelled, this function will stop polling and
+    /// throw a `CancellationError` as expected.
+    ///
+    /// - Parameters:
+    ///   - pendingRef: The pendingRef value from an `EnchantedLinkResponse` object.
+    ///   - timeout: An optional number of seconds to poll for until giving up. If not
+    ///     given a default value of 2 minutes is used.
+    ///
+    /// - Returns: Upon successful authentication a `DescopeSession` is returned.
+    func pollForSession(pendingRef: String, timeout: TimeInterval?) async throws -> DescopeSession
 }
+
 
 /// Authenticate a user using an OAuth provider. Use the Descope console to configure
 /// which authentication provider you'd like to support.
@@ -317,26 +406,28 @@ public protocol DescopeOAuth {
     ///
     /// It's recommended to use `ASWebAuthenticationSession` to perform the authentication.
     ///
-    /// - Returns: A URL to redirect to in order to authenticate the user against
-    ///     the chosen provider.
-    ///
     /// - Important: Make sure a default OAuth redirect URL is configured
     ///     in the Descope console, or provideded by this call.
     ///
-    /// - Parameter provider: The provider the user wishes to be authenticated by.
-    /// - Parameter redirectURL: An optional parameter to generate the OAuth link.
+    /// - Parameters:
+    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - redirectURL: An optional parameter to generate the OAuth link.
     ///     If not given, the project default will be used.
+    ///
+    /// - Returns: A URL to redirect to in order to authenticate the user against
+    ///     the chosen provider.
     func start(provider: OAuthProvider, redirectURL: String?) async throws -> String
     
-    /// Completes an OAuth redirect chain by exchanging the code received in the
-    /// `code` URL parameter for a `DescopeSession`.
-    ///
-    /// - Returns: Upon successful exchange a `DescopeSession` is returned.
+    /// Completes an OAuth redirect chain by exchanging the code received in
+    /// the `code` URL parameter for a `DescopeSession`.
     ///
     /// - Parameter code: The code appended to the returning URL via the
     ///     `code` URL parameter.
+    ///
+    /// - Returns: Upon successful exchange a `DescopeSession` is returned.
     func exchange(code: String) async throws -> DescopeSession
 }
+
 
 /// Authenticate a user using a SSO. Use the Descope console to configure
 /// your SSO details in order for this method to work properly.
@@ -348,23 +439,24 @@ public protocol DescopeSSO {
     ///
     /// It's recommended to use `ASWebAuthenticationSession` to perform the authentication.
     ///
-    /// - Returns: A URL to redirect to in order to authenticate the user against
-    ///     the chosen provider.
-    ///
     /// - Important: Make sure a default SSO redirect URL is configured
     ///     in the Descope console, or provideded by this call.
     ///
-    /// - Parameter provider: The provider the user wishes to be authenticated by.
-    /// - Parameter redirectURL: An optional parameter to generate the SSO link.
+    /// - Parameters:
+    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - redirectURL: An optional parameter to generate the SSO link.
     ///     If not given, the project default will be used.
+    ///
+    /// - Returns: A URL to redirect to in order to authenticate the user against
+    ///     the chosen provider.
     func start(emailOrTenantName: String, redirectURL: String?) async throws -> String
     
-    /// Completes an SSO redirect chain by exchanging the code received in the
-    /// `code` URL parameter for a `DescopeSession`.
-    ///
-    /// - Returns: Upon successful exchange a `DescopeSession` is returned.
+    /// Completes an SSO redirect chain by exchanging the code received in
+    /// the `code` URL parameter for a `DescopeSession`.
     ///
     /// - Parameter code: The code appended to the returning URL via the
     ///     `code` URL parameter.
+    ///
+    /// - Returns: Upon successful exchange a `DescopeSession` is returned.
     func exchange(code: String) async throws -> DescopeSession
 }

--- a/src/types/Others.swift
+++ b/src/types/Others.swift
@@ -1,15 +1,41 @@
 
+import Foundation
+#if os(iOS)
+import UIKit
+#endif
+
+// Enums
+
 public enum DeliveryMethod: String {
     case whatsapp
     case sms
     case email
 }
 
+public enum OAuthProvider: String {
+    case facebook
+    case github
+    case google
+    case microsoft
+    case gitlab
+    case apple
+}
+
+// Structs
+
 public struct User {
     public var name: String?
     public var phone: String?
     public var email: String?
+    
+    public init(name: String? = nil, phone: String? = nil, email: String? = nil) {
+        self.name = name
+        self.phone = phone
+        self.email = email
+    }
 }
+
+// Responses
 
 public struct MeResponse {
     public var userId: String
@@ -20,16 +46,17 @@ public struct MeResponse {
     public var phone: (value: String, isVerified: Bool)?
 }
 
-public struct TOTPResponse {
-    public var provisioningURL: String
-    public var key: String
+public struct EnchantedLinkResponse {
+    public var linkId: String
+    public var pendingRef: String
 }
 
-public enum OAuthProvider: String {
-    case facebook
-    case github
-    case google
-    case microsoft
-    case gitlab
-    case apple
+public struct TOTPResponse {
+    public var provisioningURL: String
+    #if os(iOS)
+    public var image: UIImage
+    #else
+    public var image: Data
+    #endif
+    public var key: String
 }


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/2011
Fixes https://github.com/descope/etc/issues/2065
Fixes https://github.com/descope/etc/issues/2001
Fixes https://github.com/descope/etc/issues/2075
Fixes https://github.com/descope/etc/issues/2012

## Description
- Fixes above issues
- Updates and fixes in all SDK documentation comments
- Generated callback functions now copy the documentation from the source method
- Add `image` field to `TOTPResponse` whose type is `UIImage` in iOS and plain `Data` otherwise
- Enchanted link now has `checkForSession` that checks once if the authentication has been verified
- Previous behavior is now accessible by calling `pollForSession` which also accepts optional `timeout` value

## Must
- [X] Tests
- [X] Documentation (if applicable)
