### PR TITLE
Allow providing custom baseURL in DescopeConfig

### DIFF
--- a/src/sdk/Config.swift
+++ b/src/sdk/Config.swift
@@ -7,7 +7,7 @@ public struct DescopeConfig {
         self.projectId = projectId
     }
     
-    init(projectId: String, baseURL: String) {
+    public init(projectId: String, baseURL: String) {
         self.projectId = projectId
         self.baseURL = baseURL
     }


### PR DESCRIPTION
## Description
Update the `DescopeConfig` initializers so callers can override the `baseURL`
