### PR TITLE
Add `DescopeSessionManagerDelegate` to notify session changes

### DIFF
--- a/src/session/Lifecycle.swift
+++ b/src/session/Lifecycle.swift
@@ -8,6 +8,9 @@ public protocol DescopeSessionLifecycle: AnyObject {
     /// Holds the latest session value for the session manager.
     var session: DescopeSession? { get set }
     
+    /// The ``DescopeSessionManagerDelegate`` will notify the session manager of any changes.
+    var sessionManagerDelegate: DescopeSessionManagerDelegate? { get set }
+    
     /// Called by the session manager to conditionally refresh the active session.
     func refreshSessionIfNeeded() async throws -> Bool
 }
@@ -22,6 +25,7 @@ public class SessionLifecycle: DescopeSessionLifecycle {
     public let auth: DescopeAuth
     public let storage: DescopeSessionStorage
     public let logger: DescopeLogger?
+    public var sessionManagerDelegate: DescopeSessionManagerDelegate?
 
     public init(auth: DescopeAuth, storage: DescopeSessionStorage, logger: DescopeLogger?) {
         self.auth = auth
@@ -49,6 +53,7 @@ public class SessionLifecycle: DescopeSessionLifecycle {
             if let session, session.refreshToken.isExpired {
                 logger(.debug, "Session has an expired refresh token", session.refreshToken.expiresAt)
             }
+            sessionManagerDelegate?.sessionDidChange(session)
         }
     }
     

--- a/src/session/Manager.swift
+++ b/src/session/Manager.swift
@@ -1,6 +1,19 @@
 
 import Foundation
 
+/// The ``DescopeSessionManagerDelegate`` protocol is used to listen for
+/// session changes.
+///
+/// The listener is called when the session is set or cleared, and when the
+/// session is refreshed.
+public protocol DescopeSessionManagerDelegate: AnyObject {
+    /// Called when the session is set, refreshed or cleared.
+    ///
+    /// It will be called with the changed ``DescopeSession``
+    /// or `nil` if the session was cleared
+    func sessionDidChange(_ session: DescopeSession?)
+}
+
 /// The ``DescopeSessionManager`` class is used to manage an authenticated
 /// user session for an application.
 ///
@@ -75,6 +88,11 @@ public class DescopeSessionManager {
     
     /// The object that handles session lifecycle for this manager.
     private let lifecycle: DescopeSessionLifecycle
+    
+    /// The delegate can be used to get notified when session changes.
+    public var delegate: DescopeSessionManagerDelegate? {
+        return lifecycle.sessionManagerDelegate
+    }
 
     /// The active ``DescopeSession`` managed by this object.
     public var session: DescopeSession? {


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/9870

## Description
Add `DescopeSessionManagerDelegate` to allow the caller to get notified when the session changes when it is set, refreshed or cleared.

## Must
- [x] Tests
- [x] Documentation (if applicable)

