### PR TITLE
Add support for triggering DescopeFlow failures or cancellations from the flow webpage

### DIFF
--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -323,7 +323,7 @@ window.console.error = (s) => { window.webkit.messageHandlers.\(FlowBridgeMessag
 
 // Add an accessory object for calling the bridge directly
 window.descopeBridge = {}
-window.descopeBridge.abortFlow = (reason) => { window.webkit.messageHandlers.\(FlowBridgeMessage.abort.rawValue).postMessage(reason || '') }
+window.descopeBridge.abortFlow = (reason) => { window.webkit.messageHandlers.\(FlowBridgeMessage.abort.rawValue).postMessage(typeof reason == 'string' ? reason : '') }
 
 """
 
@@ -333,7 +333,7 @@ private let connectScript = """
 // Called directly below 
 function \(namespace)_connect() {
     // first check if the web-component is immediately available
-    let component = \(namespace)_find()
+    const component = \(namespace)_find()
     if (component) {
         \(namespace)_init(component)
         return
@@ -342,7 +342,7 @@ function \(namespace)_connect() {
     // periodically check if the web-component has been added to the page
     let interval
     interval = setInterval(() => {
-        let component = \(namespace)_find()
+        const component = \(namespace)_find()
         if (component) {
             clearInterval(interval)
             \(namespace)_init(component)

--- a/src/flows/FlowViewController.swift
+++ b/src/flows/FlowViewController.swift
@@ -160,6 +160,7 @@ open class DescopeFlowViewController: UIViewController {
     /// method to preserve the same behavior even if they use a different interaction for
     /// letting users cancel the flow.`
     public func cancel() {
+        flowView.delegate = nil
         delegate?.flowViewControllerDidCancel(self)
     }
 

--- a/src/flows/FlowViewController.swift
+++ b/src/flows/FlowViewController.swift
@@ -32,7 +32,8 @@ public protocol DescopeFlowViewControllerDelegate: AnyObject {
     /// Called when the flow is cancelled.
     ///
     /// The flow is cancelled either by the user tapping the Cancel button in the navigation bar,
-    /// or if the ``DescopeFlowViewController/cancel()`` method is called programmatically.
+    /// if the ``DescopeFlowViewController/cancel()`` method is called programmatically, or if
+    /// the flow fails with a ``DescopeError/flowCancelled`` error.
     func flowViewControllerDidCancel(_ controller: DescopeFlowViewController)
 
     /// Called when an error occurs in the flow.
@@ -197,7 +198,11 @@ extension DescopeFlowViewController: DescopeFlowViewDelegate {
     }
 
     public func flowViewDidFail(_ flowView: DescopeFlowView, error: DescopeError) {
-        delegate?.flowViewControllerDidFail(self, error: error)
+        if error == .flowCancelled {
+            delegate?.flowViewControllerDidCancel(self)
+        } else {
+            delegate?.flowViewControllerDidFail(self, error: error)
+        }
     }
     
     public func flowViewDidFinish(_ flowView: DescopeFlowView, response: AuthenticationResponse) {

--- a/src/sdk/SDK.swift
+++ b/src/sdk/SDK.swift
@@ -143,7 +143,7 @@ public extension DescopeSDK {
     static let name = "DescopeKit"
     
     /// The Descope SDK version
-    static let version = "0.9.13"
+    static let version = "0.9.14"
 }
 
 // Internal


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/10134

## Description
- Allow triggering `DescopeFlow` failures or cancellations by calling `window.descopeBridge.abortFlow('reason')` in the flow page
- Ensure no more delegate events are called after a `DescopeFlowViewController` is cancelled by user

## Must
- [X] Tests
- [X] Documentation (if applicable)

