### PR TITLE
Refactor DescopeLogger to support explicit unsafe logging flag

### DIFF
--- a/src/DescopeKit.swift
+++ b/src/DescopeKit.swift
@@ -13,25 +13,29 @@ public enum Descope {
     /// You will most likely want to call this function in your application's initialization code,
     /// and in most cases you'll only need to specify the `projectId`:
     ///
-    ///     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    ///         Descope.setup(projectId: "<Your-Project-Id>")
-    ///     }
+    /// ```swift
+    /// func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    ///     Descope.setup(projectId: "<Your-Project-Id>")
+    /// }
+    /// ```
     ///
     /// You can also pass a closure to this function to perform additional configuration.
     /// For example, if you want to enable debugging logs in the Descope SDK during development
     /// and you have a separate Descope project you use as a staging environment when building
     /// and testing beta versions, you can do something like this:
     ///
-    ///     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    ///         Descope.setup(projectId: "<Production-Project-Id>") { config in
-    ///             #if DEBUG
-    ///             config.logger = DescopeLogger(level: .debug)
-    ///             #endif
-    ///             if AppConfig.isBetaBuild {
-    ///                 config.projectId = "<Staging-Project-Id>"
-    ///             }
+    /// ```swift
+    /// func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    ///     Descope.setup(projectId: "<Production-Project-Id>") { config in
+    ///         #if DEBUG
+    ///         config.logger = .debugLogger
+    ///         #endif
+    ///         if AppConfig.isBetaBuild {
+    ///             config.projectId = "<Staging-Project-Id>"
     ///         }
     ///     }
+    /// }
+    /// ```
     ///
     /// - Parameters:
     ///   - projectId: The id of the Descope project can be found in
@@ -47,10 +51,12 @@ public enum Descope {
     ///
     /// You can use this ``DescopeSessionManager`` object as a shared instance to manage
     /// authenticated sessions in your application.
-    /// 
-    ///     let authResponse = try await Descope.otp.verify(with: .email, loginId: "andy@example.com", code: "123456")
-    ///     let session = DescopeSession(from: authResponse)
-    ///     Descope.sessionManager.manageSession(session)
+    ///
+    /// ```swift
+    /// let authResponse = try await Descope.otp.verify(with: .email, loginId: "andy@example.com", code: "123456")
+    /// let session = DescopeSession(from: authResponse)
+    /// Descope.sessionManager.manageSession(session)
+    /// ```
     ///
     /// See the documentation for ``DescopeSessionManager`` for more details.
     @MainActor

--- a/src/internal/http/DescopeClient.swift
+++ b/src/internal/http/DescopeClient.swift
@@ -558,7 +558,7 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         return headers
     }
     
-    override func errorForResponseData(_ data: Data) -> Error? {
+    override func errorForResponseData(_ data: Data) -> DescopeError? {
         return DescopeError(errorResponse: data)
     }
     

--- a/src/internal/http/HTTPClient.swift
+++ b/src/internal/http/HTTPClient.swift
@@ -50,7 +50,7 @@ class HTTPClient {
         return 15
     }
     
-    func errorForResponseData(_ data: Data) -> Error? {
+    func errorForResponseData(_ data: Data) -> DescopeError? {
         return nil
     }
     
@@ -58,32 +58,55 @@ class HTTPClient {
     
     private func call(_ route: String, method: String, headers: [String: String], params: [String: String?], body: Data?) async throws -> (Data, HTTPURLResponse) {
         let request = try makeRequest(route: route, method: method, headers: headers, params: params, body: body)
-        logger(.info, "Starting network call", request.url)
-        #if DEBUG
-        if let body = request.httpBody, let requestBody = String(bytes: body, encoding: .utf8) {
-            logger(.debug, "Sending request body", requestBody)
+        if logger.isUnsafeEnabled {
+            logger.info("Starting network call", request.url)
+            if let body = request.httpBody, let requestBody = String(bytes: body, encoding: .utf8) {
+                logger.debug("Sending request body", requestBody)
+            }
+        } else {
+            logger.info("Starting network call to \(route)")
         }
-        #endif
-        
-        let (data, response) = try await sendRequest(request)
-        
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await networkClient.call(request: request)
+        } catch {
+            if logger.isUnsafeEnabled {
+                logger.error("Network call failed with network error", request.url, error)
+            } else {
+                logger.error("Network call to \(route) failed with \((error as NSError).code) network error")
+            }
+            throw DescopeError.networkError.with(cause: error)
+        }
+
         guard let response = response as? HTTPURLResponse else { throw DescopeError(httpError: .invalidResponse) }
-        #if DEBUG
-        if let responseBody = String(bytes: data, encoding: .utf8) {
-            logger(.debug, "Received response body", responseBody)
+        if logger.isUnsafeEnabled, let responseBody = String(bytes: data, encoding: .utf8) {
+            logger.debug("Received response body", responseBody)
         }
-        #endif
-        
+
         if let error = DescopeError(httpStatusCode: response.statusCode) {
             if let responseError = errorForResponseData(data) {
-                logger(.info, "Network call failed with server error", request.url, responseError)
+                if logger.isUnsafeEnabled {
+                    logger.error("Network call failed with server error", request.url, responseError)
+                } else {
+                    logger.error("Network call to \(route) failed with \(responseError.code) server error")
+                }
                 throw responseError
             }
-            logger(.info, "Network call failed with http error", request.url, error)
+            if logger.isUnsafeEnabled {
+                logger.error("Network call failed with \(response.statusCode) http error", request.url, error)
+            } else {
+                logger.error("Network call to \(route) failed with \(response.statusCode) http error")
+            }
             throw error
         }
         
-        logger(.info, "Network call finished", request.url)
+        if logger.isUnsafeEnabled {
+            logger.info("Network call finished", request.url)
+        } else {
+            logger.info("Network call to \(route) finished")
+        }
+
         return (data, response)
     }
     
@@ -108,15 +131,6 @@ class HTTPClient {
         }
         guard let url = components.url else { throw DescopeError(httpError: .invalidRoute) }
         return url
-    }
-    
-    private func sendRequest(_ request: URLRequest) async throws -> (Data, URLResponse) {
-        do {
-            return try await networkClient.call(request: request)
-        } catch {
-            logger(.error, "Network call failed with network error", request.url, error)
-            throw DescopeError.networkError.with(cause: error)
-        }
     }
 }
 

--- a/src/internal/others/Deprecated.swift
+++ b/src/internal/others/Deprecated.swift
@@ -50,6 +50,13 @@ public extension DescopeConfig {
     }
 }
 
+public extension DescopeLogger {
+    @available(*, deprecated, message: "Use DescopeLogger.basicLogger or DescopeLogger.debugLogger to diagnose issues during development")
+    convenience init(level: Level = .debug) {
+        self.init(level: level, unsafe: false)
+    }
+}
+
 public extension DescopeFlow {
     @available(*, deprecated, renamed: "oauthNativeProvider")
     var oauthProvider: OAuthProvider? {

--- a/src/internal/others/Internal.swift
+++ b/src/internal/others/Internal.swift
@@ -19,9 +19,47 @@ extension DescopeError {
     }
 }
 
+extension DescopeLogger {
+    class ConsoleLogger: DescopeLogger, @unchecked Sendable {
+        static let basic = ConsoleLogger(level: .info, unsafe: false)
+
+        static let debug = ConsoleLogger(level: .debug, unsafe: isDebuggerAttached())
+
+        static let unsafe = ConsoleLogger(level: .debug, unsafe: true)
+
+        override func output(level: Level, message: String, unsafe values: [Any]) {
+            var text = "[\(DescopeSDK.name)] \(message)"
+            if !values.isEmpty {
+                text += " (" + values.map { String(describing: $0) }.joined(separator: ", ") + ")"
+            }
+            print(text)
+        }
+
+        private static func isDebuggerAttached() -> Bool {
+            var mib = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+            var result = kinfo_proc()
+            var size = MemoryLayout.size(ofValue: result)
+            guard sysctl(&mib, UInt32(mib.count), &result, &size, nil, 0) == EXIT_SUCCESS else { return false }
+            return result.kp_proc.p_flag & P_TRACED != 0
+        }
+    }
+}
+
 extension DescopeLogger? {
-    func callAsFunction(_ level: DescopeLogger.Level, _ message: StaticString, _ values: Any?...) {
-        self?.log(level, message, values)
+    var isUnsafeEnabled: Bool {
+        return self?.unsafe == true
+    }
+
+    func error(_ message: String, _ values: Any?...) {
+        self?.log(.error, message, values)
+    }
+
+    func info(_ message: String, _ values: Any?...) {
+        self?.log(.info, message, values)
+    }
+
+    func debug(_ message: String, _ values: Any?...) {
+        self?.log(.debug, message, values)
     }
 }
 
@@ -107,7 +145,6 @@ class AuthorizationDelegate: NSObject, ASAuthorizationControllerDelegate {
     }
 }
 
-#if os(iOS) && canImport(React)
 extension AuthenticationResponse: Codable {
     enum CodingKeys: String, CodingKey {
         case sessionToken = "sessionJwt"
@@ -132,4 +169,3 @@ extension AuthenticationResponse: Codable {
         try values.encode(isFirstAuthentication, forKey: .isFirstAuthentication)
     }
 }
-#endif

--- a/src/internal/others/WebAuth.swift
+++ b/src/internal/others/WebAuth.swift
@@ -32,7 +32,7 @@ private func presentWebAuthentication(url: URL, accessSharedUserData: Bool, logg
             }
 
             cancellation = { @MainActor [weak session] in
-                logger(.info, "Web authentication cancelled programmatically")
+                logger.info("Web authentication cancelled programmatically")
                 session?.cancel()
             }
 
@@ -47,19 +47,19 @@ private func presentWebAuthentication(url: URL, accessSharedUserData: Bool, logg
 
     switch result {
     case .failure(ASWebAuthenticationSessionError.canceledLogin):
-        logger(.info, "Web authentication cancelled by user")
+        logger.info("Web authentication cancelled by user")
         throw DescopeError.webAuthCancelled
     case .failure(ASWebAuthenticationSessionError.presentationContextInvalid):
-        logger(.error, "Invalid presentation context for web authentication")
+        logger.error("Invalid presentation context for web authentication")
         throw DescopeError.webAuthFailed.with(message: "Invalid presentation context")
     case .failure(ASWebAuthenticationSessionError.presentationContextNotProvided):
-        logger(.error, "No presentation context for web authentication")
+        logger.error("No presentation context for web authentication")
         throw DescopeError.webAuthFailed.with(message: "No presentation context")
     case .failure(let error):
-        logger(.error, "Unexpected error from web authentication", error)
+        logger.error("Unexpected error from web authentication", error)
         throw DescopeError.webAuthFailed.with(cause: error)
     case .success(let callbackURL):
-        logger(.debug, "Processing OAuth web authentication", callbackURL)
+        logger.debug("Processing OAuth web authentication", callbackURL)
         return callbackURL
     }
 }

--- a/src/internal/routes/EnchantedLink.swift
+++ b/src/internal/routes/EnchantedLink.swift
@@ -34,7 +34,7 @@ final class EnchantedLink: DescopeEnchantedLink, Route {
     
     func pollForSession(pendingRef: String, timeout: TimeInterval?) async throws -> AuthenticationResponse {
         let pollingEndsAt = Date() + (timeout ?? defaultPollDuration)
-        logger(.info, "Polling for enchanted link", timeout ?? defaultPollDuration)
+        logger.info("Polling for enchanted link", timeout ?? defaultPollDuration)
         while true {
             do {
                 // ensure that the async task hasn't been cancelled
@@ -42,16 +42,16 @@ final class EnchantedLink: DescopeEnchantedLink, Route {
                 // check for the session once, any errors not specifically handled
                 // below are intentionally let through to the calling code
                 let response = try await checkForSession(pendingRef: pendingRef)
-                logger(.info, "Enchanted link authentication succeeded")
+                logger.info("Enchanted link authentication succeeded")
                 return response
             } catch DescopeError.enchantedLinkPending {
-                logger(.debug, "Waiting for enchanted link")
+                logger.debug("Waiting for enchanted link")
                 // sleep for a second before checking again
                 try await Task.sleep(nanoseconds: NSEC_PER_SEC)
                 // if the timer's expired then we throw a specific error that
                 // can be handled appropriately by the calling code
                 guard Date() < pollingEndsAt else {
-                    logger(.error, "Timed out while polling for enchanted link")
+                    logger.error("Timed out while polling for enchanted link")
                     throw DescopeError.enchantedLinkExpired
                 }
             } catch let error as DescopeError where error == .networkError {
@@ -62,10 +62,10 @@ final class EnchantedLink: DescopeEnchantedLink, Route {
                 // error as that was probably the cause, rather than the
                 // user not verifying the enchanted link email
                 guard Date() < pollingEndsAt else {
-                    logger(.error, "Timed out with network error while polling for enchanted link", error)
+                    logger.error("Timed out with network error while polling for enchanted link", error)
                     throw error
                 }
-                logger(.debug, "Ignoring network error while polling for enchanted link", error)
+                logger.debug("Ignoring network error while polling for enchanted link", error)
             }
         }
     }

--- a/src/internal/routes/Passkey.swift
+++ b/src/internal/routes/Passkey.swift
@@ -12,13 +12,13 @@ final class Passkey: DescopePasskey, Route {
     @MainActor
     @available(iOS 15.0, *)
     func signUp(loginId: String, details: SignUpDetails?) async throws -> AuthenticationResponse {
-        logger(.info, "Starting passkey sign up", loginId)
+        logger.info("Starting passkey sign up", loginId)
         let startResponse = try await client.passkeySignUpStart(loginId: loginId, details: details)
         
-        logger(.info, "Requesting register authorization for passkey sign up", startResponse.transactionId)
+        logger.info("Requesting register authorization for passkey sign up", startResponse.transactionId)
         let registerResponse = try await performRegister(options: startResponse.options)
         
-        logger(.info, "Finishing passkey sign up", startResponse.transactionId)
+        logger.info("Finishing passkey sign up", startResponse.transactionId)
         let jwtResponse = try await client.passkeySignUpFinish(transactionId: startResponse.transactionId, response: registerResponse)
 
         guard !Task.isCancelled else { throw DescopeError.passkeyCancelled }
@@ -28,14 +28,14 @@ final class Passkey: DescopePasskey, Route {
     @MainActor
     @available(iOS 15.0, *)
     func signIn(loginId: String, options: [SignInOptions]) async throws -> AuthenticationResponse {
-        logger(.info, "Starting passkey sign in", loginId)
+        logger.info("Starting passkey sign in", loginId)
         let (refreshJwt, loginOptions) = try options.convert()
         let startResponse = try await client.passkeySignInStart(loginId: loginId, refreshJwt: refreshJwt, options: loginOptions)
         
-        logger(.info, "Requesting assertion authorization for passkey sign in", startResponse.transactionId)
+        logger.info("Requesting assertion authorization for passkey sign in", startResponse.transactionId)
         let assertionResponse = try await performAssertion(options: startResponse.options)
 
-        logger(.info, "Finishing passkey sign in", startResponse.transactionId)
+        logger.info("Finishing passkey sign in", startResponse.transactionId)
         let jwtResponse = try await client.passkeySignInFinish(transactionId: startResponse.transactionId, response: assertionResponse)
         
         guard !Task.isCancelled else { throw DescopeError.passkeyCancelled }
@@ -45,20 +45,20 @@ final class Passkey: DescopePasskey, Route {
     @MainActor
     @available(iOS 15.0, *)
     func signUpOrIn(loginId: String, options: [SignInOptions]) async throws -> AuthenticationResponse {
-        logger(.info, "Starting passkey sign up or in", loginId)
+        logger.info("Starting passkey sign up or in", loginId)
         let (refreshJwt, loginOptions) = try options.convert()
         let startResponse = try await client.passkeySignUpInStart(loginId: loginId, refreshJwt: refreshJwt, options: loginOptions)
         
         let jwtResponse: DescopeClient.JWTResponse
         if startResponse.create {
-            logger(.info, "Requesting register authorization for passkey sign up or in", startResponse.transactionId)
+            logger.info("Requesting register authorization for passkey sign up or in", startResponse.transactionId)
             let registerResponse = try await performRegister(options: startResponse.options)
-            logger(.info, "Finishing passkey sign up", startResponse.transactionId)
+            logger.info("Finishing passkey sign up", startResponse.transactionId)
             jwtResponse = try await client.passkeySignUpFinish(transactionId: startResponse.transactionId, response: registerResponse)
         } else {
-            logger(.info, "Requesting assertion authorization for passkey sign up or in", startResponse.transactionId)
+            logger.info("Requesting assertion authorization for passkey sign up or in", startResponse.transactionId)
             let assertionResponse = try await performAssertion(options: startResponse.options)
-            logger(.info, "Finishing passkey sign in", startResponse.transactionId)
+            logger.info("Finishing passkey sign in", startResponse.transactionId)
             jwtResponse = try await client.passkeySignInFinish(transactionId: startResponse.transactionId, response: assertionResponse)
         }
         
@@ -69,13 +69,13 @@ final class Passkey: DescopePasskey, Route {
     @MainActor
     @available(iOS 15.0, *)
     func add(loginId: String, refreshJwt: String) async throws {
-        logger(.info, "Starting passkey update", loginId)
+        logger.info("Starting passkey update", loginId)
         let startResponse = try await client.passkeyAddStart(loginId: loginId, refreshJwt: refreshJwt)
         
-        logger(.info, "Requesting register authorization for passkey update", startResponse.transactionId)
+        logger.info("Requesting register authorization for passkey update", startResponse.transactionId)
         let registerResponse = try await performRegister(options: startResponse.options)
         
-        logger(.info, "Finishing passkey update", startResponse.transactionId)
+        logger.info("Finishing passkey update", startResponse.transactionId)
         try await client.passkeyAddFinish(transactionId: startResponse.transactionId, response: registerResponse)
     }
 
@@ -145,16 +145,16 @@ final class Passkey: DescopePasskey, Route {
 
         switch result {
         case .failure(ASAuthorizationError.canceled):
-            logger(.info, "Passkey authorization cancelled")
+            logger.info("Passkey authorization cancelled")
             throw DescopeError.passkeyCancelled
         case .failure(let error as NSError) where error.domain == "WKErrorDomain" && error.code == 31:
-            logger(.error, "Passkey authorization timed out", error)
+            logger.error("Passkey authorization timed out", error)
             throw DescopeError.passkeyCancelled.with(message: "The operation timed out")
         case .failure(let error):
-            logger(.error, "Passkey authorization failed", error)
+            logger.error("Passkey authorization failed", error)
             throw DescopeError.passkeyFailed.with(cause: error)
         case .success(let authorization):
-            logger(.debug, "Processing passkey authorization", authorization)
+            logger.debug("Processing passkey authorization", authorization)
             return authorization
         }
     }

--- a/src/sdk/Config.swift
+++ b/src/sdk/Config.swift
@@ -12,16 +12,29 @@ public struct DescopeConfig {
     /// An optional object to handle logging in the Descope SDK.
     ///
     /// The default value of this property is `nil` and thus logging will be completely
-    /// disabled. During development if you encounter any issues you can create an
-    /// instance of the ``DescopeLogger`` class to enable logging.
+    /// disabled. You can set this to ``DescopeLogger/basicLogger`` to print error and info
+    /// log messages to the console.
     ///
-    ///     Descope.setup(projectId: "...") { config in
-    ///         config.logger = DescopeLogger()
-    ///     }
+    /// If you encounter any issues you can also use ``DescopeLogger/debugLogger`` to
+    /// enable more verbose logging. This will configure a simple logger that prints all
+    /// logs to the console. If the logger detects that a debugger is attached (i.e., the
+    /// app is running in Xcode) it will also output potentially sensitive runtime values,
+    /// such as full network request and response payloads, secrets and tokens in clear text, etc.
+    ///
+    /// ```swift
+    /// Descope.setup(projectId: "...") { config in
+    ///     config.logger = .debugLogger
+    /// }
+    /// ```
+    ///
+    /// In rare cases you might need to use ``DescopeLogger/unsafeLogger`` which skips the
+    /// debugger check and always prints all log data including all sensitive runtime values.
+    /// Make sure you don't use ``DescopeLogger/unsafeLogger`` in release builds intended
+    /// for production.
     ///
     /// If your application uses some logging framework or third party service you can forward
-    /// the Descope SDK log messages to it by creating a new subclass of ``DescopeLogger`` and
-    /// overriding the `output` method.
+    /// the Descope SDK log messages to it by subclassing ``DescopeLogger`` and overriding
+    /// the `output` method. See the documentation for ``DescopeLogger`` for more details.
     public var logger: DescopeLogger?
 
     /// An optional object to override how HTTP requests are performed.
@@ -35,63 +48,20 @@ public struct DescopeConfig {
     public var networkClient: DescopeNetworkClient?
 }
 
-/// The ``DescopeLogger`` class can be used to customize logging functionality in the Descope SDK.
-///
-/// The default behavior is for log messages to be written to the standard output using
-/// the `print()` function.
-///
-/// You can also customize how logging functions in the Descope SDK by creating a subclass
-/// of ``DescopeLogger`` and overriding the ``output(level:message:debug:)`` method. See the
-/// documentation for that method for more details.
-///
-/// - Important: Runtime values such as request bodies or responses are only included
-///     in log messages when the SDK is compiled in debug mode. Even with a custom subclass
-///     of ``DescopeLogger``, when the SDK is compiled for release the log messages will only
-///     contain constant strings.
-open class DescopeLogger {
-    /// The severity of a log message.
-    public enum Level: Int {
-        case error, info, debug
-    }
-    
-    /// The maximum log level that should be printed.
-    public let level: Level
-    
-    /// Creates a new ``DescopeLogger`` object.
-    public init(level: Level = .debug) {
-        self.level = level
-    }
+/// Built-in console loggers for use during development.
+extension DescopeLogger {
+    /// A simple logger that prints basic error and info logs to the console.
+    public static let basicLogger: DescopeLogger = ConsoleLogger.basic
 
-    /// Formats the log message and prints it.
+    /// A simple logger that prints all logs to the console, but does not output any
+    /// potentially unsafe runtime values unless a debugger is attached.
+    public static let debugLogger: DescopeLogger = ConsoleLogger.debug
+
+    /// A simple logger that prints all logs to the console, including potentially unsafe
+    /// runtime values such as secrets, personal information, network payloads, etc.
     ///
-    /// Override this method to customize how to handle log messages from the Descope SDK.
-    ///
-    /// - Parameters:
-    ///   - level: The log level of the message.
-    ///   - message: This parameter is guaranteed to be a constant compile-time string, so
-    ///     you can assume it doesn't contain private user data or secrets and that it can
-    ///     be sent to whatever logging target or service you use.
-    ///   - debug: This array has runtime values that might be useful when debugging
-    ///     issues with the Descope SDK. Since it might contain sensitive information
-    ///     its contents are only provided in `debug` builds. In `release` builds it
-    ///     is always an empty array.
-    open func output(level: Level, message: StaticString, debug: [Any]) {
-        var text = "[\(DescopeSDK.name)] \(message)"
-        if !debug.isEmpty {
-            text += " (" + debug.map { String(describing: $0) }.joined(separator: ", ") + ")"
-        }
-        print(text)
-    }
-    
-    /// Called by other code in the Descope SDK to output log messages.
-    public func log(_ level: Level, _ message: StaticString, _ values: Any?...) {
-        guard level.rawValue <= self.level.rawValue else { return }
-        #if DEBUG
-        output(level: level, message: message, debug: values.compactMap { $0 })
-        #else
-        output(level: level, message: message, debug: [])
-        #endif
-    }
+    /// - Important: Do not use unsafeLogger in release builds intended for production.
+    public static let unsafeLogger: DescopeLogger = ConsoleLogger.unsafe
 }
 
 /// The ``DescopeNetworkClient`` protocol can be used to override how HTTP requests

--- a/src/sdk/Logger.swift
+++ b/src/sdk/Logger.swift
@@ -1,0 +1,72 @@
+
+/// The ``DescopeLogger`` class can be used if you need to customize how logging works in the
+/// Descope SDK, but in most cases you can simply use ``DescopeLogger/debugLogger`` (see the
+/// documentation for the ``DescopeConfig/logger`` property in ``DescopeConfig`` for more details).
+///
+/// Create a subclass of ``DescopeLogger`` and override the ``output(level:message:unsafe:)``
+/// method. See the documentation for that method for more details.
+///
+/// ```swift
+/// Descope.setup(projectId: "...") { config in
+///     config.logger = RemoteDescopeLogger()
+/// }
+///
+/// // elsewhere
+///
+/// class RemoteDescopeLogger: DescopeLogger {
+///     init() {
+///         super.init(level: .info, unsafe: false)
+///     }
+///
+///     override func output(level: Level, message: String, unsafe values: [Any]) {
+///         RemoteLogger.sendLog("Descope: \(message)")
+///     }
+/// }
+/// ```
+///
+/// The logging functions might be called concurrently on multiple threads, so you
+/// should make sure your subclass implementation is thread safe.
+open class DescopeLogger: @unchecked Sendable {
+    /// The severity of a log message.
+    public enum Level: Int, Sendable {
+        case error, info, debug
+    }
+
+    /// The maximum log level that should be printed.
+    public let level: Level
+
+    /// Whether to print unsafe runtime value.
+    public let unsafe: Bool
+
+    /// Creates a new ``DescopeLogger`` object.
+    ///
+    /// - Parameters:
+    ///   - level: The maximum log level that should be printed.
+    ///   - unsafe: Whether logs should include unsafe runtime values such as secrets,
+    ///     personal information, network payloads, etc. This flag should never be
+    ///     enabled in release builds intended for production.
+    public init(level: Level, unsafe: Bool) {
+        self.level = level
+        self.unsafe = unsafe
+    }
+
+    /// Called by other code in the Descope SDK to output log messages.
+    public func log(_ level: Level, _ message: String, _ values: Any?...) {
+        guard level.rawValue <= self.level.rawValue else { return }
+        let values = unsafe ? values : []
+        output(level: level, message: message, unsafe: values.compactMap { $0 })
+    }
+
+    /// Override this method to implement formatting and printing of logs from the Descope SDK.
+    ///
+    /// - Parameters:
+    ///   - level: The log level of the message.
+    ///   - message: The log message is guaranteed to be a plain string that's safe for logging.
+    ///     You can assume it doesn't contain any secrets, user data, or personal information
+    ///     and that it can be safely printed or sent to a third party logging service.
+    ///   - values: This array has runtime values that might be useful when debugging issues
+    ///     with the Descope SDK. As these values are not considered safe this array is always
+    ///     empty unless the logger was created with `unsafe` set to `true`.
+    open func output(level: Level, message: String, unsafe values: [Any]) {
+    }
+}

--- a/src/session/Lifecycle.swift
+++ b/src/session/Lifecycle.swift
@@ -48,7 +48,7 @@ public class SessionLifecycle: DescopeSessionLifecycle {
                 resetTimer()
             }
             if let session, session.refreshToken.isExpired {
-                logger(.debug, "Session has an expired refresh token", session.refreshToken.expiresAt)
+                logger.debug("Session has an expired refresh token", session.refreshToken.expiresAt)
             }
         }
     }
@@ -56,11 +56,11 @@ public class SessionLifecycle: DescopeSessionLifecycle {
     public func refreshSessionIfNeeded() async throws -> Bool {
         guard let current = session, shouldRefresh(current) else { return false }
 
-        logger(.info, "Refreshing session that is about to expire", current.sessionToken.expiresAt.timeIntervalSinceNow)
+        logger.info("Refreshing session that is about to expire", current.sessionToken.expiresAt.timeIntervalSinceNow)
         let response = try await auth.refreshSession(refreshJwt: current.refreshJwt)
 
         guard session?.sessionJwt == current.sessionJwt else {
-            logger(.info, "Skipping refresh because session has changed in the meantime")
+            logger.info("Skipping refresh because session has changed in the meantime")
             return false
         }
 
@@ -109,7 +109,7 @@ public class SessionLifecycle: DescopeSessionLifecycle {
 
     private func periodicRefresh() async {
         if let refreshToken = session?.refreshToken, refreshToken.isExpired {
-            logger(.debug, "Stopping periodic refresh for session with expired refresh token")
+            logger.debug("Stopping periodic refresh for session with expired refresh token")
             stopTimer()
             return
         }
@@ -117,13 +117,13 @@ public class SessionLifecycle: DescopeSessionLifecycle {
         do {
             let refreshed = try await refreshSessionIfNeeded()
             if refreshed {
-                logger(.debug, "Periodic session refresh succeeded")
+                logger.debug("Periodic session refresh succeeded")
                 onPeriodicRefresh()
             }
         } catch DescopeError.networkError {
-            logger(.debug, "Ignoring network error in periodic refresh")
+            logger.debug("Ignoring network error in periodic refresh")
         } catch {
-            logger(.error, "Stopping periodic refresh after failure", error)
+            logger.error("Stopping periodic refresh after failure", error)
             stopTimer()
         }
     }


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/10329

## Description
- Add built-in loggers `.basicLogger` and `.debugLogger` for common case of wanting to see logs in the console during app development.
- Refactor `DescopeLogger` to support explicit `unsafe` logging flag.
- Remove most references to `DEBUG` compilation flag.
- Improve error logs by always printing some runtime value that are guaranteed to be safe such as error codes and URL routes are always sent in logs.

## Must
- [X] Tests
- [X] Documentation (if applicable)

