### PR TITLE
Expose more customization points in the KeychainStore class

### DIFF
--- a/src/flows/FlowView.swift
+++ b/src/flows/FlowView.swift
@@ -47,7 +47,7 @@ public protocol DescopeFlowViewDelegate: AnyObject {
 ///
 /// You can use a flow view as the main view of a modal authentication screen or as part of a
 /// more complex view hierarchy. In the former case you might consider using a ``DescopeFlowViewController``
-/// instead, as it provides simple way to present an authentication flow modally.
+/// instead, as it provides a simpler way to present an authentication flow modally.
 ///
 /// You can create an instance of ``DescopeFlowView``, add it to the view hierarchy, and call
 /// ``start(flow:)`` to load the flow.

--- a/src/sdk/Callbacks.swift
+++ b/src/sdk/Callbacks.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // Regenerate by running:


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/11147
Fixes https://github.com/descope/descope-swift/issues/103

## Description
- Expose more customization points in the `SessionStorage.KeychainStore` class.
- This allow changing the accessibility of new keychain items, as well as customizing the item attributes.

## Must
- [X] Tests
- [X] Documentation (if applicable)

