### PR TITLE
Fix issue with explicit Descope.oauth.web calls not respecting the accessSharedUserData parameter

### DIFF
--- a/src/internal/others/WebAuth.swift
+++ b/src/internal/others/WebAuth.swift
@@ -40,6 +40,7 @@ private func presentWebAuthentication(url: URL, accessSharedUserData: Bool, logg
             }
 
             session.presentationContextProvider = contextProvider
+            session.prefersEphemeralWebBrowserSession = !accessSharedUserData
             session.start()
         }
     } onCancel: {


### PR DESCRIPTION

## Description
- Fix issue with explicit `Descope.oauth.web` calls not respecting the `accessSharedUserData` parameter.

## Must
- [X] Tests
- [X] Documentation (if applicable)
