### PR TITLE
Log and return CF-Ray response header in API failures

### DIFF
--- a/src/internal/http/HTTPClient.swift
+++ b/src/internal/http/HTTPClient.swift
@@ -85,20 +85,22 @@ class HTTPClient {
         }
 
         if let error = DescopeError(httpStatusCode: response.statusCode) {
+            let cfray = response.value(forHTTPHeaderField: "cf-ray")
+            let trace = cfray.map { " [CF-Ray: \($0)]" } ?? ""
             if let responseError = errorForResponseData(data) {
                 if logger.isUnsafeEnabled {
-                    logger.error("Network call failed with server error", request.url, responseError)
+                    logger.error("Network call failed with server error\(trace)", request.url, responseError)
                 } else {
-                    logger.error("Network call to \(route) failed with \(responseError.code) server error")
+                    logger.error("Network call to \(route) failed with \(responseError.code) server error\(trace)")
                 }
-                throw responseError
+                throw responseError.with(traceId: cfray)
             }
             if logger.isUnsafeEnabled {
-                logger.error("Network call failed with \(response.statusCode) http error", request.url, error)
+                logger.error("Network call failed with \(response.statusCode) http error\(trace)", request.url, error)
             } else {
-                logger.error("Network call to \(route) failed with \(response.statusCode) http error")
+                logger.error("Network call to \(route) failed with \(response.statusCode) http error\(trace)")
             }
-            throw error
+            throw error.with(traceId: cfray)
         }
         
         if logger.isUnsafeEnabled {
@@ -189,6 +191,15 @@ private func mergeHeaders(_ headers: [String: String], with defaults: [String: S
     result.merge(defaults, uniquingKeysWith: { $1 })
     result.merge(headers, uniquingKeysWith: { $1 })
     return result
+}
+
+// Errors
+
+private extension DescopeError {
+    func with(traceId: String?) -> DescopeError {
+        guard let traceId else { return self }
+        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
+    }
 }
 
 // Network

--- a/src/internal/others/Internal.swift
+++ b/src/internal/others/Internal.swift
@@ -7,15 +7,15 @@ extension DescopeSDK {
 
 extension DescopeError {
     func with(desc: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
+        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
     }
     
     func with(message: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
+        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
     }
     
     func with(cause: Error) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
+        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
     }
 }
 

--- a/src/types/Error.swift
+++ b/src/types/Error.swift
@@ -63,6 +63,16 @@ public struct DescopeError: Error {
     /// call. When a ``DescopeError/passkeyFailed`` error is thrown the ``cause`` property
     /// will often contain an instance of AuthorizationError.
     public var cause: Error?
+
+    /// An optional trace identifier for a failed network request.
+    ///
+    /// When the Descope server is accessed through its CDN (the default), this holds the
+    /// value of the `CF-Ray` response header of the failed request. You can log this value
+    /// or send it to Descope support to help trace and diagnose server errors.
+    ///
+    /// This is `nil` for errors that aren't associated with a server response, such as
+    /// ``DescopeError/networkError``, or when the response didn't include the header.
+    public var traceId: String?
 }
 
 /// A list of common ``DescopeError`` values that can be thrown by the Descope SDK.
@@ -142,6 +152,9 @@ extension DescopeError: CustomStringConvertible {
         }
         if let cause {
             str += ", cause: {\(cause)}"
+        }
+        if let traceId {
+            str += ", traceId: \"\(traceId)\""
         }
         str += ")"
         return str

--- a/test/http/HTTPClient.swift
+++ b/test/http/HTTPClient.swift
@@ -84,6 +84,60 @@ class TestHttpMethods: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+
+    func testTraceId() async throws {
+        let logger = CapturingLogger()
+        let client = HTTPClient(baseURL: "http://example", logger: logger, networkClient: MockHTTP.networkClient)
+
+        // the CF-Ray header is exposed on the error and included in the failure log
+        do {
+            MockHTTP.push(statusCode: 400, json: [:], headers: ["CF-Ray": "8a1b2c3d4e5f6789-IAD"])
+            try await client.get("route")
+            XCTFail("No error thrown")
+        } catch let err as DescopeError {
+            XCTAssertEqual(err.traceId, "8a1b2c3d4e5f6789-IAD")
+            XCTAssertTrue(logger.messages.contains { $0.contains("8a1b2c3d4e5f6789-IAD") }, "Expected the CF-Ray to appear in the failure log")
+        }
+
+        // no CF-Ray header means no trace identifier
+        do {
+            MockHTTP.push(statusCode: 400, json: [:])
+            try await client.get("route")
+            XCTFail("No error thrown")
+        } catch let err as DescopeError {
+            XCTAssertNil(err.traceId)
+        }
+    }
+
+    func testTraceIdForServerError() async throws {
+        let client = ParsingHTTPClient(baseURL: "http://example", logger: nil, networkClient: MockHTTP.networkClient)
+        do {
+            MockHTTP.push(statusCode: 400, json: ["errorCode": "E061102", "errorMessage": "failed to validate nonce"], headers: ["CF-Ray": "abc123def456-IAD"])
+            try await client.get("route")
+            XCTFail("No error thrown")
+        } catch let err as DescopeError {
+            XCTAssertEqual(err.code, "E061102")
+            XCTAssertEqual(err.traceId, "abc123def456-IAD")
+        }
+    }
+}
+
+private final class CapturingLogger: DescopeLogger, @unchecked Sendable {
+    nonisolated(unsafe) var messages: [String] = []
+
+    init() {
+        super.init(level: .debug, unsafe: false)
+    }
+
+    override func output(level: Level, message: String, unsafe values: [Any]) {
+        messages.append(message)
+    }
+}
+
+private final class ParsingHTTPClient: HTTPClient {
+    override func errorForResponseData(_ data: Data) -> DescopeError? {
+        return DescopeError(errorResponse: data)
+    }
 }
 
 private let mockBodyJSON: [String: Sendable] = ["foo": 4]

--- a/test/http/HTTPClient.swift
+++ b/test/http/HTTPClient.swift
@@ -109,7 +109,7 @@ class TestHttpMethods: XCTestCase {
         }
     }
 
-    func testTraceIdForServerError() async throws {
+    func testTraceIdForErrorResponse() async throws {
         let client = ParsingHTTPClient(baseURL: "http://example", logger: nil, networkClient: MockHTTP.networkClient)
         do {
             MockHTTP.push(statusCode: 400, json: ["errorCode": "E061102", "errorMessage": "failed to validate nonce"], headers: ["CF-Ray": "abc123def456-IAD"])


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/15547

## Description
- Log and return CF-Ray response header in API failures

## Must
- [X] Tests
- [X] Documentation (if applicable)