### PR TITLE
Map server flow cancellation error to flowCancelled

### DIFF
--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -224,7 +224,15 @@ extension FlowBridge {
             }
         case .failure:
             logger.error("Bridge received failure event", message.body)
-            if let dict = message.body as? [String: Any], let error = DescopeError(errorResponse: dict) {
+            if let dict = message.body as? [String: Any], var error = DescopeError(errorResponse: dict) {
+                // Convert server flow cancellation to local flow cancellation for cohesive error handling
+                if error.code == "E102122" {
+                    if let message = error.message {
+                        error = DescopeError.flowCancelled.with(message: message)
+                    } else {
+                        error = DescopeError.flowCancelled
+                    }
+                }
                 delegate?.bridgeDidFailAuthentication(self, error: error)
             } else if let reason = message.body as? String, !reason.isEmpty {
                 delegate?.bridgeDidFailAuthentication(self, error: DescopeError.flowFailed.with(message: reason))

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -225,13 +225,8 @@ extension FlowBridge {
         case .failure:
             logger.error("Bridge received failure event", message.body)
             if let dict = message.body as? [String: Any], var error = DescopeError(errorResponse: dict) {
-                // Convert server flow cancellation to local flow cancellation for cohesive error handling
-                if error.code == "E102122" {
-                    if let message = error.message {
-                        error = DescopeError.flowCancelled.with(message: message)
-                    } else {
-                        error = DescopeError.flowCancelled
-                    }
+                if error.code == "E102122" { // convert server-side flow aborted error to client-side flow cancelled error
+                    error = DescopeError.flowCancelled.with(message: error.message)
                 }
                 delegate?.bridgeDidFailAuthentication(self, error: error)
             } else if let reason = message.body as? String, !reason.isEmpty {
@@ -294,7 +289,7 @@ extension FlowBridge: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation, withError error: Error) {
-        var error = error as NSError
+        let error = error as NSError
         
         // Ignore navigation cancellations that are an expected part of the navigation lifecycle
         // due to, e.g., redirects,

--- a/src/internal/http/HTTPClient.swift
+++ b/src/internal/http/HTTPClient.swift
@@ -193,15 +193,6 @@ private func mergeHeaders(_ headers: [String: String], with defaults: [String: S
     return result
 }
 
-// Errors
-
-private extension DescopeError {
-    func with(traceId: String?) -> DescopeError {
-        guard let traceId else { return self }
-        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
-    }
-}
-
 // Network
 
 private final class DefaultNetworkClient: DescopeNetworkClient {

--- a/src/internal/others/Internal.swift
+++ b/src/internal/others/Internal.swift
@@ -6,16 +6,21 @@ extension DescopeSDK {
 }
 
 extension DescopeError {
-    func with(desc: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
-    }
-    
-    func with(message: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
-    }
-    
-    func with(cause: Error) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause, traceId: traceId)
+    func with(desc: String? = nil, message: String? = nil, cause: Error? = nil, traceId: String? = nil) -> DescopeError {
+        var error = self
+        if let desc, !desc.isEmpty {
+            error.desc = desc
+        }
+        if let message, !message.isEmpty {
+            error.message = message
+        }
+        if let cause {
+            error.cause = cause
+        }
+        if let traceId, !traceId.isEmpty {
+            error.traceId = traceId
+        }
+        return error
     }
 }
 

--- a/test/http/HTTPClient.swift
+++ b/test/http/HTTPClient.swift
@@ -94,8 +94,8 @@ class TestHttpMethods: XCTestCase {
             MockHTTP.push(statusCode: 400, json: [:], headers: ["CF-Ray": "8a1b2c3d4e5f6789-IAD"])
             try await client.get("route")
             XCTFail("No error thrown")
-        } catch let err as DescopeError {
-            XCTAssertEqual(err.traceId, "8a1b2c3d4e5f6789-IAD")
+        } catch {
+            XCTAssertEqual(error.traceId, "8a1b2c3d4e5f6789-IAD")
             XCTAssertTrue(logger.messages.contains { $0.contains("8a1b2c3d4e5f6789-IAD") }, "Expected the CF-Ray to appear in the failure log")
         }
 
@@ -104,8 +104,8 @@ class TestHttpMethods: XCTestCase {
             MockHTTP.push(statusCode: 400, json: [:])
             try await client.get("route")
             XCTFail("No error thrown")
-        } catch let err as DescopeError {
-            XCTAssertNil(err.traceId)
+        } catch {
+            XCTAssertNil(error.traceId)
         }
     }
 
@@ -115,9 +115,9 @@ class TestHttpMethods: XCTestCase {
             MockHTTP.push(statusCode: 400, json: ["errorCode": "E061102", "errorMessage": "failed to validate nonce"], headers: ["CF-Ray": "abc123def456-IAD"])
             try await client.get("route")
             XCTFail("No error thrown")
-        } catch let err as DescopeError {
-            XCTAssertEqual(err.code, "E061102")
-            XCTAssertEqual(err.traceId, "abc123def456-IAD")
+        } catch {
+            XCTAssertEqual(error.code, "E061102")
+            XCTAssertEqual(error.traceId, "abc123def456-IAD")
         }
     }
 }


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16441

## Related PRs
https://github.com/descope/descope-kotlin/pull/329

## Description
- `FlowBridge` failure handler maps server `errorCode` `E102122` to `DescopeError.flowCancelled`, preserving any `errorMessage` from the payload

## Must
- [ ] Tests
- [ ] Documentation