### PR TITLE
feat: expose externalToken on AuthenticationResponse

### DIFF
--- a/src/internal/http/DescopeClient.swift
+++ b/src/internal/http/DescopeClient.swift
@@ -447,6 +447,7 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         var cookieDomain: String?
         var cookieName: String?
         var sessionCookieName: String?
+        var externalToken: String?
 
         mutating func setValues(from data: Data, response: HTTPURLResponse) throws {
             guard let url = response.url, let fields = response.allHeaderFields as? [String: String] else { return }

--- a/src/internal/routes/Shared.swift
+++ b/src/internal/routes/Shared.swift
@@ -73,7 +73,7 @@ extension DescopeClient.JWTResponse {
         guard let sessionJwt, !sessionJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing session JWT") }
         guard let refreshJwt, !refreshJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing refresh JWT") }
         guard let user else { throw DescopeError.decodeError.with(message: "Missing user details") }
-        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen)
+        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen, externalToken: externalToken)
     }
 }
 

--- a/src/types/Responses.swift
+++ b/src/types/Responses.swift
@@ -10,6 +10,7 @@ public struct AuthenticationResponse: Sendable {
     public var refreshToken: DescopeToken
     public var user: DescopeUser
     public var isFirstAuthentication: Bool
+    public var externalToken: String?
 }
 
 /// Returned from the ``DescopeAuth/refreshSession(refreshJwt:)`` call.

--- a/test/http/JWTResponse.swift
+++ b/test/http/JWTResponse.swift
@@ -32,6 +32,22 @@ class TestJWTResponse: XCTestCase {
         XCTAssertEqual("qux", authResponse.refreshToken.entityId)
     }
 
+    func testExternalToken() async throws {
+        // with external token
+        var data = Data(externalTokenPayload.utf8)
+        var jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
+        try jwtResponse.setValues(from: data, cookies: [], refreshCookieName: nil)
+        var authResponse: AuthenticationResponse = try jwtResponse.convert()
+        XCTAssertEqual("ext-token-value", authResponse.externalToken)
+
+        // no external token
+        data = Data(noExternalTokenPayload.utf8)
+        jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
+        try jwtResponse.setValues(from: data, cookies: [], refreshCookieName: nil)
+        authResponse = try jwtResponse.convert()
+        XCTAssertNil(authResponse.externalToken)
+    }
+
     func testPageCookie() async throws {
         let data = Data(authPayload.utf8)
 
@@ -87,6 +103,25 @@ private let authPayload = """
 {
     "sessionJwt": "\(sessionJwt)",
     "refreshJwt": "",
+    "user": \(userPayload),
+    "firstSeen": true
+}
+"""
+
+private let externalTokenPayload = """
+{
+    "sessionJwt": "\(sessionJwt)",
+    "refreshJwt": "\(refreshJwt)",
+    "user": \(userPayload),
+    "firstSeen": true,
+    "externalToken": "ext-token-value"
+}
+"""
+
+private let noExternalTokenPayload = """
+{
+    "sessionJwt": "\(sessionJwt)",
+    "refreshJwt": "\(refreshJwt)",
     "user": \(userPayload),
     "firstSeen": true
 }


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16830

## Related PRs
https://github.com/descope/descope-kotlin/pull/336
https://github.com/descope/descope-js/pull/1435

## Description
- Populate `AuthenticationResponse.externalToken: String?` from the server auth response
- Decoded on `JWTResponse` and passed through `convert()`, matching the Flutter and web SDKs

## Must
- [x] Tests
- [ ] Documentation