### PR TITLE
feat(flows): pass the session JWT to the flow bridge

### DIFF
--- a/src/flows/Flow.swift
+++ b/src/flows/Flow.swift
@@ -147,6 +147,14 @@ public class DescopeFlow {
     ///     This is especially important for projects that use refresh token rotation.
     public var sessionProvider: (() -> DescopeSession?)?
 
+    /// Whether to send the current session JWT on flow start/next requests, exposing
+    /// its validated claims to the flow via the `sessionJwtClaims` context key
+    /// (e.g. checking the `su` step-up claim). Off by default.
+    ///
+    /// The session is taken from the ``sessionProvider`` or the SDK's session manager,
+    /// same as for authenticated flows.
+    public var sendSessionToken: Bool = false
+
     /// Creates a new ``DescopeFlow`` object that encapsulates a single flow run.
     ///
     /// - Parameter url: The URL where the flow is hosted.

--- a/src/flows/Flow.swift
+++ b/src/flows/Flow.swift
@@ -147,14 +147,6 @@ public class DescopeFlow {
     ///     This is especially important for projects that use refresh token rotation.
     public var sessionProvider: (() -> DescopeSession?)?
 
-    /// Whether to send the current session JWT on flow start/next requests, exposing
-    /// its validated claims to the flow via the `sessionJwtClaims` context key
-    /// (e.g. checking the `su` step-up claim). Off by default.
-    ///
-    /// The session is taken from the ``sessionProvider`` or the SDK's session manager,
-    /// same as for authenticated flows.
-    public var sendSessionToken: Bool = false
-
     /// Creates a new ``DescopeFlow`` object that encapsulates a single flow run.
     ///
     /// - Parameter url: The URL where the flow is hosted.

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -146,6 +146,12 @@ extension FlowBridge {
             logger.info("Passing refreshJwt to flow initialization", session.refreshJwt)
             refreshJwt = session.refreshJwt
         }
+
+        // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it)
+        if flow.sendSessionToken, let session = flow.providedSession {
+            logger.info("Passing sessionJwt to flow initialization")
+            nativeOptions.sessionJwt = session.sessionJwt
+        }
         
         var clientInputs = ""
         if !flow.clientInputs.isEmpty {
@@ -451,6 +457,7 @@ private struct FlowNativeOptions: Encodable {
     var ssoRedirect = WebAuth.redirectURL
     var externalAuthRedirect = WebAuth.redirectURL
     var magicLinkRedirect = ""
+    var sessionJwt: String?
 
     var payload: String {
         guard let data = try? JSONEncoder().encode(self), let value = String(bytes: data, encoding: .utf8) else { return "{}" }

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -150,12 +150,13 @@ extension FlowBridge {
             refreshJwt = session.refreshJwt
         }
 
-        // passed to the web component like the refresh JWT; the web component decides
-        // whether to send it on flow requests (send-session-token). An expired session
+        // injected into the page's local storage like the refresh JWT, but only for
+        // web components that opted in via send-session-token. An expired session
         // token is skipped so the flow never sees stale claims
+        var sessionJwt = ""
         if let session, !session.sessionToken.isExpired {
             logger.info("Passing sessionJwt to flow initialization")
-            nativeOptions.sessionJwt = session.sessionJwt
+            sessionJwt = session.sessionJwt
         }
         
         var clientInputs = ""
@@ -168,7 +169,7 @@ extension FlowBridge {
             }
         }
         
-        call(function: "initialize", params: nativeOptions.payload, refreshJwt, clientInputs)
+        call(function: "initialize", params: nativeOptions.payload, refreshJwt, sessionJwt, clientInputs)
     }
 
     /// Called by the coordinator when it needs to update the refresh token in the page.
@@ -462,7 +463,6 @@ private struct FlowNativeOptions: Encodable {
     var ssoRedirect = WebAuth.redirectURL
     var externalAuthRedirect = WebAuth.redirectURL
     var magicLinkRedirect = ""
-    var sessionJwt: String?
 
     var payload: String {
         guard let data = try? JSONEncoder().encode(self), let value = String(bytes: data, encoding: .utf8) else { return "{}" }
@@ -564,12 +564,13 @@ window.descopeBridge = {
             return true
         },
 
-        initialize(nativeOptions, refreshJwt, clientInputs) {
+        initialize(nativeOptions, refreshJwt, sessionJwt, clientInputs) {
             // update webpage sdk headers and print sdk type and version to native log
             this.updateConfigHeaders()
 
             this.component.nativeOptions = JSON.parse(nativeOptions)
             this.updateRefreshJwt(refreshJwt)
+            this.updateSessionJwt(sessionJwt)
             this.updateClientInputs(clientInputs)
             
             if (this.component.flowStatus === 'error') {
@@ -656,6 +657,16 @@ window.descopeBridge = {
                 const storagePrefix = this.component.storagePrefix || ''
                 const storageKey = `${storagePrefix}\(DescopeClient.refreshCookieName)`
                 window.localStorage.setItem(storageKey, refreshJwt)
+            }
+        },
+
+        updateSessionJwt(sessionJwt) {
+            // the session JWT is only made available to web components that opted in
+            // via the send-session-token attribute
+            if (sessionJwt && this.component.getAttribute('send-session-token') === 'true') {
+                const storagePrefix = this.component.storagePrefix || ''
+                const storageKey = `${storagePrefix}\(DescopeClient.sessionCookieName)`
+                window.localStorage.setItem(storageKey, sessionJwt)
             }
         },
 

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -147,8 +147,9 @@ extension FlowBridge {
             refreshJwt = session.refreshJwt
         }
 
-        // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it)
-        if flow.sendSessionToken, let session = flow.providedSession {
+        // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it);
+        // an expired session token is skipped so the flow never sees stale claims
+        if flow.sendSessionToken, let session = flow.providedSession, !session.sessionToken.isExpired {
             logger.info("Passing sessionJwt to flow initialization")
             nativeOptions.sessionJwt = session.sessionJwt
         }

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -177,6 +177,11 @@ extension FlowBridge {
         call(function: "updateRefreshJwt", params: refreshJwt)
     }
 
+    /// Called by the coordinator when it needs to update the session token in the page.
+    func updateSessionJwt(_ sessionJwt: String) {
+        call(function: "updateSessionJwt", params: sessionJwt)
+    }
+
     /// Called by the coordinator when it's done handling a bridge request
     func postResponse(_ response: FlowBridgeResponse) {
         call(function: "handleResponse", params: response.type, response.payload)
@@ -662,11 +667,14 @@ window.descopeBridge = {
 
         updateSessionJwt(sessionJwt) {
             // the session JWT is only made available to web components that opted in
-            // via the send-session-token attribute
+            // via the send-session-token attribute; cleared otherwise so a value from
+            // a previous session never lingers in the page's persistent storage
+            const storagePrefix = this.component.storagePrefix || ''
+            const storageKey = `${storagePrefix}\(DescopeClient.sessionCookieName)`
             if (sessionJwt && this.component.getAttribute('send-session-token') === 'true') {
-                const storagePrefix = this.component.storagePrefix || ''
-                const storageKey = `${storagePrefix}\(DescopeClient.sessionCookieName)`
                 window.localStorage.setItem(storageKey, sessionJwt)
+            } else {
+                window.localStorage.removeItem(storageKey)
             }
         },
 

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -150,9 +150,10 @@ extension FlowBridge {
             refreshJwt = session.refreshJwt
         }
 
-        // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it);
-        // an expired session token is skipped so the flow never sees stale claims
-        if flow.sendSessionToken, let session, !session.sessionToken.isExpired {
+        // passed to the web component like the refresh JWT; the web component decides
+        // whether to send it on flow requests (send-session-token). An expired session
+        // token is skipped so the flow never sees stale claims
+        if let session, !session.sessionToken.isExpired {
             logger.info("Passing sessionJwt to flow initialization")
             nativeOptions.sessionJwt = session.sessionJwt
         }

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -141,15 +141,18 @@ extension FlowBridge {
         nativeOptions.oauthProvider = flow.oauthNativeProvider?.name ?? ""
         nativeOptions.magicLinkRedirect = flow.magicLinkRedirect ?? ""
 
+        // take one session snapshot so refreshJwt and sessionJwt can't come from different sessions
+        let session = flow.providedSession
+
         var refreshJwt = ""
-        if let session = flow.providedSession {
+        if let session {
             logger.info("Passing refreshJwt to flow initialization", session.refreshJwt)
             refreshJwt = session.refreshJwt
         }
 
         // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it);
         // an expired session token is skipped so the flow never sees stale claims
-        if flow.sendSessionToken, let session = flow.providedSession, !session.sessionToken.isExpired {
+        if flow.sendSessionToken, let session, !session.sessionToken.isExpired {
             logger.info("Passing sessionJwt to flow initialization")
             nativeOptions.sessionJwt = session.sessionJwt
         }

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -666,9 +666,6 @@ window.descopeBridge = {
         },
 
         updateSessionJwt(sessionJwt) {
-            // the session JWT is only made available to web components that opted in
-            // via the send-session-token attribute; cleared otherwise so a value from
-            // a previous session never lingers in the page's persistent storage
             const storagePrefix = this.component.storagePrefix || ''
             const storageKey = `${storagePrefix}\(DescopeClient.sessionCookieName)`
             if (sessionJwt && this.component.getAttribute('send-session-token') === 'true') {

--- a/src/flows/FlowCoordinator.swift
+++ b/src/flows/FlowCoordinator.swift
@@ -228,6 +228,7 @@ public class DescopeFlowCoordinator {
     private func updateRefreshJwt() {
         guard let session = flow?.providedSession else { return }
         bridge.updateRefreshJwt(session.refreshJwt)
+        bridge.updateSessionJwt(session.sessionToken.isExpired ? "" : session.sessionJwt)
     }
 
     // Resume


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17811

## Related PRs
### Related PRs
- https://github.com/descope/descope-kotlin/pull/356
- https://github.com/descope/descope-react-native/pull/184

## In a Nutshell
- The flow bridge injects the current session JWT into the page's local storage, same as the refresh JWT
- Injected only for web components that opted in via the `send-session-token` attribute
- No new API; expired session tokens are skipped, one session snapshot feeds both JWTs

## Description
Web components with `send-session-token` enabled read the session JWT from web storage and send it on flow start/next requests, so a flow can check the validated session claims server side (for example whether the user already completed step-up) via the `sessionJwtClaims` flow context key. The bridge now makes the native session JWT available in the page's local storage the same way it already does for the refresh JWT - but only when the web component carries the opt-in attribute, so the token never enters page storage otherwise.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)